### PR TITLE
Consolidate platform-agnostic client code from the Jenkins plugins into one place within this library

### DIFF
--- a/gcp-client/pom.xml
+++ b/gcp-client/pom.xml
@@ -21,33 +21,38 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <!--TODO(stephenashank) Prepare for maven release -->
   <artifactId>gcp-client</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <name>GCP Plugin Clients</name>
   <description>These classes provide shared GCP client functionality.</description>
 
+  <properties>
+    <container.revision>57</container.revision>
+    <compute.revision>214</compute.revision>
+    <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-container</artifactId>
-      <version>v1-rev57-1.25.0</version>
+      <version>v1-rev${container.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-compute</artifactId>
-      <version>v1-rev199-1.22.0</version>
+      <version>v1-rev${compute.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-cloudresourcemanager</artifactId>
-      <version>v1-rev535-1.25.0</version>
+      <version>v1-rev${cloudresourcemanager.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.25.0</version>
+      <version>${google.api.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/gcp-client/pom.xml
+++ b/gcp-client/pom.xml
@@ -31,6 +31,7 @@
     <container.revision>57</container.revision>
     <compute.revision>214</compute.revision>
     <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
+    <durian.version>3.4.0</durian.version>
   </properties>
 
   <dependencies>
@@ -53,6 +54,11 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>${google.api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.diffplug.durian</groupId>
+      <artifactId>durian</artifactId>
+      <version>${durian.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/gcp-client/pom.xml
+++ b/gcp-client/pom.xml
@@ -32,6 +32,7 @@
     <compute.revision>214</compute.revision>
     <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
     <durian.version>3.4.0</durian.version>
+    <awaitility.version>3.1.6</awaitility.version>
   </properties>
 
   <dependencies>
@@ -59,6 +60,11 @@
       <groupId>com.diffplug.durian</groupId>
       <artifactId>durian</artifactId>
       <version>${durian.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/gcp-client/pom.xml
+++ b/gcp-client/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.graphite</groupId>
+    <artifactId>gcp-plugin-core-java</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <!--TODO(stephenashank) Prepare for maven release -->
+  <artifactId>gcp-client</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>GCP Plugin Clients</name>
+  <description>These classes provide shared GCP client functionality.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-container</artifactId>
+      <version>v1-rev57-1.25.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-compute</artifactId>
+      <version>v1-rev199-1.22.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudresourcemanager</artifactId>
+      <version>v1-rev535-1.25.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>1.25.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -58,18 +58,20 @@ public class ClientFactory {
 
   public CloudResourceManagerClient cloudResourceManagerClient() {
     return new CloudResourceManagerClient(
-        new CloudResourceManager.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(this::initializeRequest)
-            .setApplicationName(applicationName)
-            .build());
+        new CloudResourceManagerWrapper(
+            new CloudResourceManager.Builder(transport, jsonFactory, httpRequestInitializer)
+                .setGoogleClientRequestInitializer(this::initializeRequest)
+                .setApplicationName(applicationName)
+                .build()));
   }
 
   public ContainerClient containerClient() {
     return new ContainerClient(
-        new Container.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(this::initializeRequest)
-            .setApplicationName(applicationName)
-            .build());
+        new ContainerWrapper(
+            new Container.Builder(transport, jsonFactory, httpRequestInitializer)
+                .setGoogleClientRequestInitializer(this::initializeRequest)
+                .setApplicationName(applicationName)
+                .build()));
   }
 
   private void initializeRequest(final AbstractGoogleClientRequest request) {

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -17,6 +17,7 @@
 package com.google.graphite.platforms.plugin.client;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -48,10 +49,7 @@ public class ClientFactory {
   public ComputeClient computeClient() {
     return new ComputeClient(
         new Compute.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(
-                request ->
-                    request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setGoogleClientRequestInitializer(this::initializeRequest)
             .setApplicationName(applicationName)
             .build());
   }
@@ -59,10 +57,7 @@ public class ClientFactory {
   public CloudResourceManagerClient cloudResourceManagerClient() {
     return new CloudResourceManagerClient(
         new CloudResourceManager.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(
-                request ->
-                    request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setGoogleClientRequestInitializer(this::initializeRequest)
             .setApplicationName(applicationName)
             .build());
   }
@@ -70,11 +65,12 @@ public class ClientFactory {
   public ContainerClient containerClient() {
     return new ContainerClient(
         new Container.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(
-                request ->
-                    request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setGoogleClientRequestInitializer(this::initializeRequest)
             .setApplicationName(applicationName)
             .build());
+  }
+
+  private void initializeRequest(AbstractGoogleClientRequest request) {
+    request.setRequestHeaders(request.getRequestHeaders().setUserAgent(applicationName));
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.container.Container;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+
+public class ClientFactory {
+  private HttpTransport transport;
+  private JsonFactory jsonFactory;
+  private HttpRequestInitializer httpRequestInitializer;
+  private String applicationName;
+
+  public ClientFactory(
+      Optional<HttpTransport> httpTransport,
+      HttpRequestInitializer httpRequestInitializer,
+      String applicationName)
+      throws IOException, GeneralSecurityException {
+    this.transport = httpTransport.orElse(GoogleNetHttpTransport.newTrustedTransport());
+    this.jsonFactory = new JacksonFactory();
+    this.httpRequestInitializer = httpRequestInitializer;
+    this.applicationName = applicationName;
+  }
+
+  public ComputeClient computeClient() {
+    return new ComputeClient(
+        new Compute.Builder(transport, jsonFactory, httpRequestInitializer)
+            .setGoogleClientRequestInitializer(
+                request ->
+                    request.setRequestHeaders(
+                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setApplicationName(applicationName)
+            .build());
+  }
+
+  public CloudResourceManagerClient cloudResourceManagerClient() {
+    return new CloudResourceManagerClient(
+        new CloudResourceManager.Builder(transport, jsonFactory, httpRequestInitializer)
+            .setGoogleClientRequestInitializer(
+                request ->
+                    request.setRequestHeaders(
+                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setApplicationName(applicationName)
+            .build());
+  }
+
+  public ContainerClient containerClient() {
+    return new ContainerClient(
+        new Container.Builder(transport, jsonFactory, httpRequestInitializer)
+            .setGoogleClientRequestInitializer(
+                request ->
+                    request.setRequestHeaders(
+                        request.getRequestHeaders().setUserAgent(applicationName)))
+            .setApplicationName(applicationName)
+            .build());
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -30,12 +30,27 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Optional;
 
+/**
+ * A factory for generating clients which provide convenience methods for the GCP client libraries.
+ */
 public class ClientFactory {
   private final HttpTransport transport;
   private final JsonFactory jsonFactory;
   private final HttpRequestInitializer httpRequestInitializer;
   private final String applicationName;
 
+  /**
+   * Constructor for {@link ClientFactory}.
+   *
+   * @param httpTransport An optional HTTP Transport for making HTTP requests. If not specified, the
+   *     default trusted NetHttpTransport will be generated.
+   * @param httpRequestInitializer Used to initialize HTTP requests, and must contain the Credential
+   *     for authenticating requests.
+   * @param applicationName The name of the application which is using the clients in order to tie
+   *     this information to requests to track usage.
+   * @throws IOException If generating a new trusted HTTP Transport failed
+   * @throws GeneralSecurityException If generating a new trusted HTTP Transport failed due to
+   */
   public ClientFactory(
       final Optional<HttpTransport> httpTransport,
       final HttpRequestInitializer httpRequestInitializer,
@@ -47,6 +62,11 @@ public class ClientFactory {
     this.applicationName = Preconditions.checkNotNull(applicationName);
   }
 
+  /**
+   * Initializes a {@link ComputeClient} with the properties of this {@link ClientFactory}.
+   *
+   * @return A {@link ComputeClient} for interacting with the Google Compute Engine API.
+   */
   public ComputeClient computeClient() {
     return new ComputeClient(
         new ComputeWrapper(
@@ -56,6 +76,13 @@ public class ClientFactory {
                 .build()));
   }
 
+  /**
+   * Initializes a {@link CloudResourceManagerClient} with the properties of this {@link
+   * ClientFactory}.
+   *
+   * @return A {@link CloudResourceManagerClient} for interacting with the Cloud Resource Manger
+   *     API.
+   */
   public CloudResourceManagerClient cloudResourceManagerClient() {
     return new CloudResourceManagerClient(
         new CloudResourceManagerWrapper(
@@ -65,6 +92,11 @@ public class ClientFactory {
                 .build()));
   }
 
+  /**
+   * Initializes a {@link ContainerClient} with the properties of this {@link ClientFactory}.
+   *
+   * @return A {@link ContainerClient} for interacting with the Google Kubernetes Engine API.
+   */
   public ContainerClient containerClient() {
     return new ContainerClient(
         new ContainerWrapper(

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -29,10 +29,10 @@ import java.security.GeneralSecurityException;
 import java.util.Optional;
 
 public class ClientFactory {
-  private HttpTransport transport;
-  private JsonFactory jsonFactory;
-  private HttpRequestInitializer httpRequestInitializer;
-  private String applicationName;
+  private final HttpTransport transport;
+  private final JsonFactory jsonFactory;
+  private final HttpRequestInitializer httpRequestInitializer;
+  private final String applicationName;
 
   public ClientFactory(
       Optional<HttpTransport> httpTransport,

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -49,10 +49,11 @@ public class ClientFactory {
 
   public ComputeClient computeClient() {
     return new ComputeClient(
-        new Compute.Builder(transport, jsonFactory, httpRequestInitializer)
-            .setGoogleClientRequestInitializer(this::initializeRequest)
-            .setApplicationName(applicationName)
-            .build());
+        new ComputeWrapper(
+            new Compute.Builder(transport, jsonFactory, httpRequestInitializer)
+                .setGoogleClientRequestInitializer(this::initializeRequest)
+                .setApplicationName(applicationName)
+                .build()));
   }
 
   public CloudResourceManagerClient cloudResourceManagerClient() {

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -25,6 +25,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.container.Container;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Optional;
@@ -42,8 +43,8 @@ public class ClientFactory {
       throws IOException, GeneralSecurityException {
     this.transport = httpTransport.orElse(GoogleNetHttpTransport.newTrustedTransport());
     this.jsonFactory = new JacksonFactory();
-    this.httpRequestInitializer = httpRequestInitializer;
-    this.applicationName = applicationName;
+    this.httpRequestInitializer = Preconditions.checkNotNull(httpRequestInitializer);
+    this.applicationName = Preconditions.checkNotNull(applicationName);
   }
 
   public ComputeClient computeClient() {

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ClientFactory.java
@@ -36,9 +36,9 @@ public class ClientFactory {
   private final String applicationName;
 
   public ClientFactory(
-      Optional<HttpTransport> httpTransport,
-      HttpRequestInitializer httpRequestInitializer,
-      String applicationName)
+      final Optional<HttpTransport> httpTransport,
+      final HttpRequestInitializer httpRequestInitializer,
+      final String applicationName)
       throws IOException, GeneralSecurityException {
     this.transport = httpTransport.orElse(GoogleNetHttpTransport.newTrustedTransport());
     this.jsonFactory = new JacksonFactory();
@@ -70,7 +70,7 @@ public class ClientFactory {
             .build());
   }
 
-  private void initializeRequest(AbstractGoogleClientRequest request) {
+  private void initializeRequest(final AbstractGoogleClientRequest request) {
     request.setRequestHeaders(request.getRequestHeaders().setUserAgent(applicationName));
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -46,7 +46,7 @@ public class CloudResourceManagerClient {
   /**
    * Retrieves a list of Projects for the credentials associated with this client.
    *
-   * @return The retrieved list of projects.
+   * @return The retrieved list of projects sorted by project ID.
    * @throws IOException When an error occurred attempting to get the projects.
    */
   public ImmutableList<Project> listProjects() throws IOException {

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -16,6 +16,8 @@
 
 package com.google.graphite.platforms.plugin.client;
 
+import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
+
 import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.base.Preconditions;
@@ -51,13 +53,6 @@ public class CloudResourceManagerClient {
    */
   public ImmutableList<Project> getAccountProjects() throws IOException {
     List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
-    if (projects == null) {
-      projects = ImmutableList.of();
-    }
-
-    // Sort by project ID
-    projects.sort(Comparator.comparing(Project::getProjectId));
-
-    return ImmutableList.copyOf(projects);
+    return processResourceList(projects, Comparator.comparing(Project::getProjectId));
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -18,7 +18,6 @@ package com.google.graphite.platforms.plugin.client;
 
 import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
 
-import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -32,15 +31,15 @@ import java.util.Comparator;
  *     API</a>
  */
 public class CloudResourceManagerClient {
-  private final CloudResourceManager cloudResourceManager;
+  private final CloudResourceManagerWrapper cloudResourceManager;
 
   /**
    * Constructs a new {@link CloudResourceManagerClient} instance.
    *
-   * @param cloudResourceManager The {@link CloudResourceManager} instance this class will utilize
-   *     for interacting with the Cloud Resource Manager API.
+   * @param cloudResourceManager The {@link CloudResourceManagerWrapper} instance this class will
+   *     utilize for interacting with the Cloud Resource Manager API.
    */
-  public CloudResourceManagerClient(final CloudResourceManager cloudResourceManager) {
+  public CloudResourceManagerClient(final CloudResourceManagerWrapper cloudResourceManager) {
     this.cloudResourceManager = Preconditions.checkNotNull(cloudResourceManager);
   }
 
@@ -52,7 +51,6 @@ public class CloudResourceManagerClient {
    */
   public ImmutableList<Project> getAccountProjects() throws IOException {
     return processResourceList(
-        cloudResourceManager.projects().list().execute().getProjects(),
-        Comparator.comparing(Project::getProjectId));
+        cloudResourceManager.listProjects(), Comparator.comparing(Project::getProjectId));
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -24,7 +24,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.List;
 
 /**
  * Client for communicating with the Google Cloud Research Manager API.
@@ -52,7 +51,8 @@ public class CloudResourceManagerClient {
    * @throws IOException When an error occurred attempting to get the projects.
    */
   public ImmutableList<Project> getAccountProjects() throws IOException {
-    List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
-    return processResourceList(projects, Comparator.comparing(Project::getProjectId));
+    return processResourceList(
+        cloudResourceManager.projects().list().execute().getProjects(),
+        Comparator.comparing(Project::getProjectId));
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -46,10 +46,10 @@ public class CloudResourceManagerClient {
   /**
    * Retrieves a list of Projects for the credentials associated with this client.
    *
-   * @return The retrieved list of projects
+   * @return The retrieved list of projects.
    * @throws IOException When an error occurred attempting to get the projects.
    */
-  public ImmutableList<Project> getAccountProjects() throws IOException {
+  public ImmutableList<Project> listProjects() throws IOException {
     return processResourceList(
         cloudResourceManager.listProjects(), Comparator.comparing(Project::getProjectId));
   }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -41,7 +41,7 @@ public class CloudResourceManagerClient {
    * @param cloudResourceManager The {@link CloudResourceManager} instance this class will utilize
    *     for interacting with the Cloud Resource Manager API.
    */
-  public CloudResourceManagerClient(CloudResourceManager cloudResourceManager) {
+  public CloudResourceManagerClient(final CloudResourceManager cloudResourceManager) {
     this.cloudResourceManager = Preconditions.checkNotNull(cloudResourceManager);
   }
 

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClient.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Client for communicating with the Google Cloud Research Manager API.
+ *
+ * @see <a href="https://cloud.google.com/resource-manager/reference/rest/">Cloud Research Manager
+ *     API</a>
+ */
+public class CloudResourceManagerClient {
+  private final CloudResourceManager cloudResourceManager;
+
+  /**
+   * Constructs a new {@link CloudResourceManagerClient} instance.
+   *
+   * @param cloudResourceManager The {@link CloudResourceManager} instance this class will utilize
+   *     for interacting with the Cloud Resource Manager API.
+   */
+  public CloudResourceManagerClient(CloudResourceManager cloudResourceManager) {
+    this.cloudResourceManager = Preconditions.checkNotNull(cloudResourceManager);
+  }
+
+  /**
+   * Retrieves a list of Projects for the credentials associated with this client.
+   *
+   * @return The retrieved list of projects
+   * @throws IOException When an error occurred attempting to get the projects.
+   */
+  public ImmutableList<Project> getAccountProjects() throws IOException {
+    List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
+    if (projects == null) {
+      projects = ImmutableList.of();
+    }
+
+    // Sort by project ID
+    projects.sort(Comparator.comparing(Project::getProjectId));
+
+    return ImmutableList.copyOf(projects);
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerWrapper.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerWrapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * Internal use only. Wraps chained methods with direct calls for readability and mocking. The lack
+ * of final parameters or parameter checking is intended, this is purely for wrapping.
+ */
+class CloudResourceManagerWrapper {
+  private final CloudResourceManager cloudResourceManager;
+
+  CloudResourceManagerWrapper(CloudResourceManager cloudResourceManager) {
+    this.cloudResourceManager = cloudResourceManager;
+  }
+
+  List<Project> listProjects() throws IOException {
+    return cloudResourceManager.projects().list().execute().getProjects();
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.AcceleratorType;
+import com.google.api.services.compute.model.AttachedDisk;
+import com.google.api.services.compute.model.DiskType;
+import com.google.api.services.compute.model.Image;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceTemplate;
+import com.google.api.services.compute.model.InstancesScopedList;
+import com.google.api.services.compute.model.MachineType;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Region;
+import com.google.api.services.compute.model.Snapshot;
+import com.google.api.services.compute.model.SnapshotList;
+import com.google.api.services.compute.model.Subnetwork;
+import com.google.api.services.compute.model.Zone;
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Client for communicating with the Google Compute API
+ *
+ * @see <a href="https://cloud.google.com/compute/">Cloud Engine</a>
+ */
+public class ComputeClient {
+  private Compute compute;
+
+  private static final Logger LOGGER = Logger.getLogger(ComputeClient.class.getName());
+  private static final long SNAPSHOT_TIMEOUT_MILLISECONDS = TimeUnit.MINUTES.toMillis(10);
+
+  public ComputeClient(Compute compute) {
+    setCompute(compute);
+  }
+
+  public static String nameFromSelfLink(String selfLink) {
+    return selfLink.substring(selfLink.lastIndexOf("/") + 1);
+  }
+
+  public static String buildLabelsFilterString(Map<String, String> labels) {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> l : labels.entrySet()) {
+      sb.append("(labels." + l.getKey() + " eq " + l.getValue() + ") ");
+    }
+    return sb.toString().trim();
+  }
+
+  public static List<Metadata.Items> mergeMetadataItems(
+      List<Metadata.Items> winner, List<Metadata.Items> loser) {
+    if (loser == null) {
+      loser = new ArrayList<>();
+    }
+
+    // Remove any existing metadata that has the same key(s) as what we're trying to update/append
+    for (Metadata.Items existing : loser) {
+      boolean duplicate = false;
+      for (Metadata.Items newItem : winner) { // Items to append
+        if (existing.getKey().equals(newItem.getKey())) {
+          duplicate = true;
+        }
+      }
+      if (!duplicate) {
+        winner.add(existing);
+      }
+    }
+    return winner;
+  }
+
+  public void setCompute(Compute compute) {
+    this.compute = compute;
+  }
+
+  /**
+   * @return
+   * @throws IOException
+   */
+  public List<Region> getRegions(String projectId) throws IOException {
+    List<Region> regions = compute.regions().list(projectId).execute().getItems();
+    if (regions == null) {
+      return new ArrayList<>();
+    }
+
+    // No deprecated regions
+    Iterator it = regions.iterator();
+    while (it.hasNext()) {
+      Region o = (Region) it.next();
+      if (o.getDeprecated() != null
+          && o.getDeprecated().getState().equalsIgnoreCase("DEPRECATED")) {
+        it.remove();
+      }
+    }
+
+    regions.sort(Comparator.comparing(Region::getName));
+
+    return regions;
+  }
+
+  public List<Zone> getZones(String projectId, String region) throws IOException {
+    List<Zone> zones = compute.zones().list(projectId).execute().getItems();
+    if (zones == null) {
+      return new ArrayList<>();
+    }
+
+    // Only zones for the region
+    Iterator it = zones.iterator();
+    while (it.hasNext()) {
+      Zone o = (Zone) it.next();
+      if (!o.getRegion().equals(region)) {
+        it.remove();
+      }
+    }
+
+    zones.sort(Comparator.comparing(Zone::getName));
+
+    return zones;
+  }
+
+  public List<MachineType> getMachineTypes(String projectId, String zone) throws IOException {
+    zone = nameFromSelfLink(zone);
+    List<MachineType> machineTypes =
+        compute.machineTypes().list(projectId, zone).execute().getItems();
+    if (machineTypes == null) {
+      return new ArrayList<>();
+    }
+
+    // No deprecated items
+    Iterator it = machineTypes.iterator();
+    while (it.hasNext()) {
+      MachineType o = (MachineType) it.next();
+      if (o.getDeprecated() != null
+          && o.getDeprecated().getState().equalsIgnoreCase("DEPRECATED")) {
+        it.remove();
+      }
+    }
+
+    machineTypes.sort(Comparator.comparing(MachineType::getName));
+
+    return machineTypes;
+  }
+
+  public List<String> cpuPlatforms(String projectId, String zone) throws IOException {
+    List<String> cpuPlatforms = new ArrayList<String>();
+    zone = nameFromSelfLink(zone);
+    Zone zoneObject = compute.zones().get(projectId, zone).execute();
+    if (zoneObject == null) {
+      return cpuPlatforms;
+    }
+    return zoneObject.getAvailableCpuPlatforms();
+  }
+
+  public List<DiskType> getDiskTypes(String projectId, String zone) throws IOException {
+    zone = nameFromSelfLink(zone);
+    List<DiskType> diskTypes = compute.diskTypes().list(projectId, zone).execute().getItems();
+    if (diskTypes == null) {
+      return new ArrayList<>();
+    }
+
+    // No deprecated items
+    Iterator it = diskTypes.iterator();
+    while (it.hasNext()) {
+      DiskType o = (DiskType) it.next();
+      if (o.getDeprecated() != null
+          && o.getDeprecated().getState().equalsIgnoreCase("DEPRECATED")) {
+        it.remove();
+      }
+    }
+
+    diskTypes.sort(Comparator.comparing(DiskType::getName));
+
+    return diskTypes;
+  }
+
+  public List<DiskType> getBootDiskTypes(String projectId, String zone) throws IOException {
+    zone = nameFromSelfLink(zone);
+    List<DiskType> diskTypes = this.getDiskTypes(projectId, zone);
+
+    // No local disks
+    Iterator it = diskTypes.iterator();
+    while (it.hasNext()) {
+      DiskType o = (DiskType) it.next();
+      if (o.getName().startsWith("local-")) {
+        it.remove();
+      }
+    }
+    return diskTypes;
+  }
+
+  public List<Image> getImages(String projectId) throws IOException {
+    List<Image> images = compute.images().list(projectId).execute().getItems();
+    if (images == null) {
+      return new ArrayList<>();
+    }
+
+    // No deprecated items
+    Iterator it = images.iterator();
+    while (it.hasNext()) {
+      Image o = (Image) it.next();
+      if (o.getDeprecated() != null
+          && o.getDeprecated().getState().equalsIgnoreCase("DEPRECATED")) {
+        it.remove();
+      }
+    }
+
+    images.sort(Comparator.comparing(Image::getName));
+
+    return images;
+  }
+
+  public Image getImage(String projectId, String name) throws IOException {
+    Image image = compute.images().get(projectId, name).execute();
+
+    return image;
+  }
+
+  public List<AcceleratorType> getAcceleratorTypes(String projectId, String zone)
+      throws IOException {
+    zone = nameFromSelfLink(zone);
+
+    List<AcceleratorType> acceleratorTypes =
+        compute.acceleratorTypes().list(projectId, zone).execute().getItems();
+    if (acceleratorTypes == null) {
+      return new ArrayList<>();
+    }
+
+    // No deprecated items
+    Iterator it = acceleratorTypes.iterator();
+    while (it.hasNext()) {
+      AcceleratorType o = (AcceleratorType) it.next();
+      if (o.getDeprecated() != null
+          && o.getDeprecated().getState().equalsIgnoreCase("DEPRECATED")) {
+        it.remove();
+      }
+    }
+    acceleratorTypes.sort(Comparator.comparing(AcceleratorType::getName));
+    return acceleratorTypes;
+  }
+
+  public List<Network> getNetworks(String projectId) throws IOException {
+    List<Network> networks = compute.networks().list(projectId).execute().getItems();
+
+    if (networks == null) {
+      return new ArrayList<>();
+    }
+    return networks;
+  }
+
+  public List<Subnetwork> getSubnetworks(String projectId, String networkSelfLink, String region)
+      throws IOException {
+    region = nameFromSelfLink(region);
+    List<Subnetwork> subnetworks =
+        compute.subnetworks().list(projectId, region).execute().getItems();
+    if (subnetworks == null) {
+      return new ArrayList<>();
+    }
+
+    // Only subnetworks in the parent network
+    Iterator it = subnetworks.iterator();
+    while (it.hasNext()) {
+      Subnetwork o = (Subnetwork) it.next();
+      if (!o.getNetwork().equals(networkSelfLink)) {
+        it.remove();
+      }
+    }
+
+    subnetworks.sort(Comparator.comparing(Subnetwork::getName));
+    return subnetworks;
+  }
+
+  public Operation insertInstance(String projectId, String template, Instance instance)
+      throws IOException {
+    final Compute.Instances.Insert insert =
+        compute.instances().insert(projectId, instance.getZone(), instance);
+    if (!Strings.isNullOrEmpty(template)) {
+      insert.setSourceInstanceTemplate(template);
+    }
+    return insert.execute();
+  }
+
+  public Operation terminateInstance(String projectId, String zone, String InstanceId)
+      throws IOException {
+    zone = nameFromSelfLink(zone);
+    return compute.instances().delete(projectId, zone, InstanceId).execute();
+  }
+
+  public Operation terminateInstanceWithStatus(
+      String projectId, String zone, String instanceId, String desiredStatus)
+      throws IOException, InterruptedException {
+    zone = nameFromSelfLink(zone);
+    Instance i = getInstance(projectId, zone, instanceId);
+    if (i.getStatus().equals(desiredStatus)) {
+      return compute.instances().delete(projectId, zone, instanceId).execute();
+    }
+    return null;
+  }
+
+  public Instance getInstance(String projectId, String zone, String instanceId) throws IOException {
+    zone = nameFromSelfLink(zone);
+    return compute.instances().get(projectId, zone, instanceId).execute();
+  }
+
+  /**
+   * Return all instances that contain the given labels
+   *
+   * @param projectId
+   * @param labels
+   * @return
+   * @throws IOException
+   */
+  public List<Instance> getInstancesWithLabel(String projectId, Map<String, String> labels)
+      throws IOException {
+    Compute.Instances.AggregatedList request = compute.instances().aggregatedList(projectId);
+    request.setFilter(buildLabelsFilterString(labels));
+    Map<String, InstancesScopedList> result = request.execute().getItems();
+    List<Instance> instances = new ArrayList<>();
+    for (InstancesScopedList instancesInZone : result.values()) {
+      if (instancesInZone.getInstances() != null) {
+        instances.addAll(instancesInZone.getInstances());
+      }
+    }
+    return instances;
+  }
+
+  public InstanceTemplate getTemplate(String projectId, String templateName) throws IOException {
+    return compute.instanceTemplates().get(projectId, templateName).execute();
+  }
+
+  public void insertTemplate(String projectId, InstanceTemplate instanceTemplate)
+      throws IOException {
+    compute.instanceTemplates().insert(projectId, instanceTemplate).execute();
+  }
+
+  public void deleteTemplate(String projectId, String templateName) throws IOException {
+    compute.instanceTemplates().delete(projectId, templateName).execute();
+  }
+
+  public List<InstanceTemplate> getTemplates(String projectId) throws IOException {
+    List<InstanceTemplate> instanceTemplates =
+        compute.instanceTemplates().list(projectId).execute().getItems();
+    if (instanceTemplates == null) {
+      instanceTemplates = Collections.emptyList();
+    }
+
+    // Sort by name
+    instanceTemplates.sort(Comparator.comparing(InstanceTemplate::getName));
+
+    return instanceTemplates;
+  }
+
+  /**
+   * Creates persistent disk snapshot for Compute Engine instance. This method blocks until the
+   * operation completes.
+   *
+   * @param projectId Google cloud project id (e.g. my-project).
+   * @param zone Instance's zone.
+   * @param instanceId Name of the instance whose disks to take a snapshot of.
+   * @throws IOException If an error occured in snapshot creation.
+   * @throws InterruptedException If snapshot creation is interrupted.
+   */
+  public void createSnapshot(String projectId, String zone, String instanceId)
+      throws IOException, InterruptedException {
+    try {
+      zone = nameFromSelfLink(zone);
+      Instance instance = compute.instances().get(projectId, zone, instanceId).execute();
+
+      // TODO: JENKINS-56113 parallelize snapshot creation
+      for (AttachedDisk disk : instance.getDisks()) {
+        String diskId = nameFromSelfLink(disk.getSource());
+        createSnapshotForDisk(projectId, zone, diskId);
+      }
+    } catch (InterruptedException ie) {
+      // catching InterruptedException here because calling function also can throw
+      // InterruptedException from trying to terminate node
+      LOGGER.log(Level.WARNING, "Error in creating snapshot.", ie);
+      throw ie;
+    } catch (IOException ioe) {
+      LOGGER.log(Level.WARNING, "Interruption in creating snapshot.", ioe);
+      throw ioe;
+    }
+  }
+
+  /**
+   * Given a disk's name, create a snapshot for said disk.
+   *
+   * @param projectId Google cloud project id.
+   * @param zone Zone of disk.
+   * @param diskId Name of disk to create a snapshot for.
+   * @throws IOException If an error occured in snapshot creation.
+   * @throws InterruptedException If snapshot creation is interrupted.
+   */
+  public void createSnapshotForDisk(String projectId, String zone, String diskId)
+      throws IOException, InterruptedException {
+    Snapshot snapshot = new Snapshot();
+    snapshot.setName(diskId);
+
+    Operation op = compute.disks().createSnapshot(projectId, zone, diskId, snapshot).execute();
+    // poll for result
+    waitForOperationCompletion(
+        projectId, op.getName(), op.getZone(), SNAPSHOT_TIMEOUT_MILLISECONDS);
+  }
+
+  /**
+   * Deletes persistent disk snapshot. Does not block.
+   *
+   * @param projectId Google cloud project id.
+   * @param snapshotName Name of the snapshot to be deleted.
+   * @throws IOException If an error occurred in deleting the snapshot.
+   */
+  public void deleteSnapshot(String projectId, String snapshotName) throws IOException {
+    compute.snapshots().delete(projectId, snapshotName).execute();
+  }
+
+  /**
+   * Returns snapshot with name snapshotName
+   *
+   * @param projectId Google cloud project id.
+   * @param snapshotName Name of the snapshot to get.
+   * @return Snapshot object with given snapshotName. Null if not found.
+   * @throws IOException If an error occurred in retrieving the snapshot.
+   */
+  public Snapshot getSnapshot(String projectId, String snapshotName) throws IOException {
+    SnapshotList response;
+    Compute.Snapshots.List request = compute.snapshots().list(projectId);
+
+    do {
+      response = request.execute();
+      if (response.getItems() == null) {
+        continue;
+      }
+      for (Snapshot snapshot : response.getItems()) {
+        if (snapshotName.equals(snapshot.getName())) return snapshot;
+      }
+      request.setPageToken(response.getNextPageToken());
+    } while (response.getNextPageToken() != null);
+
+    return null;
+  }
+
+  /**
+   * Appends metadata to an instance. Any metadata items with existing keys will be overwritten.
+   * Otherwise, metadata is preserved. This method blocks until the operation completes.
+   *
+   * @param projectId
+   * @param zone
+   * @param instanceId
+   * @param items
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public Operation.Error appendInstanceMetadata(
+      String projectId, String zone, String instanceId, List<Metadata.Items> items)
+      throws IOException, InterruptedException {
+    zone = nameFromSelfLink(zone);
+    Instance instance = getInstance(projectId, zone, instanceId);
+    Metadata existingMetadata = instance.getMetadata();
+
+    List<Metadata.Items> newMetadataItems = mergeMetadataItems(items, existingMetadata.getItems());
+    existingMetadata.setItems(newMetadataItems);
+
+    Operation op =
+        compute.instances().setMetadata(projectId, zone, instanceId, existingMetadata).execute();
+    return waitForOperationCompletion(projectId, op.getName(), op.getZone(), 60 * 1000);
+  }
+
+  /**
+   * Blocks until an existing operation completes.
+   *
+   * @param projectId
+   * @param operationId
+   * @param zone
+   * @param timeout
+   * @return
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public Operation.Error waitForOperationCompletion(
+      String projectId, String operationId, String zone, long timeout)
+      throws IOException, InterruptedException {
+    if (Strings.isNullOrEmpty(operationId)) {
+      throw new IllegalArgumentException("Operation ID can not be null");
+    }
+    if (Strings.isNullOrEmpty(zone)) {
+      throw new IllegalArgumentException("Zone can not be null");
+    }
+    if (zone != null) {
+      String[] bits = zone.split("/");
+      zone = bits[bits.length - 1];
+    }
+
+    Operation operation = compute.zoneOperations().get(projectId, zone, operationId).execute();
+    long start = System.currentTimeMillis();
+    final long POLL_INTERVAL = 5 * 1000;
+
+    String status = operation.getStatus();
+    while (!status.equals("DONE")) {
+      Thread.sleep(POLL_INTERVAL);
+      long elapsed = System.currentTimeMillis() - start;
+      if (elapsed >= timeout) {
+        throw new InterruptedException("Timed out waiting for operation to complete");
+      }
+      LOGGER.log(Level.FINE, "Waiting for operation " + operationId + " to complete..");
+      if (zone != null) {
+        Compute.ZoneOperations.Get get = compute.zoneOperations().get(projectId, zone, operationId);
+        operation = get.execute();
+      } else {
+        Compute.GlobalOperations.Get get = compute.globalOperations().get(projectId, operationId);
+        operation = get.execute();
+      }
+      if (operation != null) {
+        status = operation.getStatus();
+      }
+    }
+    return operation.getError();
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -67,22 +67,18 @@ public class ComputeClient {
   public static List<Metadata.Items> mergeMetadataItems(
       final List<Metadata.Items> winner, final List<Metadata.Items> loser) {
     if (loser == null) {
-      return winner;
+      return ImmutableList.copyOf(winner);
     }
 
-    // Remove any existing metadata that has the same key(s) as what we're trying to update/append
-    for (Metadata.Items existing : loser) {
-      boolean duplicate = false;
-      for (Metadata.Items newItem : winner) { // Items to append
-        if (existing.getKey().equals(newItem.getKey())) {
-          duplicate = true;
-        }
-      }
-      if (!duplicate) {
-        winner.add(existing);
-      }
-    }
-    return winner;
+    List<Metadata.Items> result = new ArrayList<>(winner);
+    // Only add items from the existing list to the result if there are no duplicates by key
+    loser
+        .stream()
+        .filter(
+            existing ->
+                winner.stream().noneMatch(newItem -> newItem.getKey().equals(existing.getKey())))
+        .forEach(result::add);
+    return ImmutableList.copyOf(result);
   }
 
   /**

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -526,7 +526,7 @@ public class ComputeClient {
     snapshot.setName(diskName);
 
     Operation op = compute.createDiskSnapshot(projectId, zoneName, diskName, snapshot);
-    return waitForOperationCompletion(projectId, op.getName(), op.getZone(), timeout);
+    return waitForOperationCompletion(projectId, op, timeout);
   }
 
   /**
@@ -607,7 +607,24 @@ public class ComputeClient {
     existingMetadata.setItems(newMetadataItems);
 
     Operation op = compute.setInstanceMetadata(projectId, zoneName, instanceId, existingMetadata);
-    return waitForOperationCompletion(projectId, op.getName(), op.getZone(), timeout);
+    return waitForOperationCompletion(projectId, op, timeout);
+  }
+
+  /**
+   * Blocks until an existing {@link Operation} completes.
+   *
+   * @param projectId The ID of the project for this {@link Operation}.
+   * @param operation The {@link Operation} to reference.
+   * @param timeout The number of milliseconds to wait for the {@link Operation} to complete.
+   * @return The {@link Operation.Error} for the completed {@link Operation}.
+   * @throws InterruptedException If the operation was not completed before the timeout.
+   */
+  public Operation.Error waitForOperationCompletion(
+      final String projectId, final Operation operation, final long timeout)
+      throws InterruptedException {
+    // Intentionally omit other argument checks to use the ones in the other method.
+    Preconditions.checkNotNull(operation);
+    return waitForOperationCompletion(projectId, operation.getName(), operation.getZone(), timeout);
   }
 
   /**

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -526,7 +526,6 @@ public class ComputeClient {
     snapshot.setName(diskName);
 
     Operation op = compute.createDiskSnapshot(projectId, zoneName, diskName, snapshot);
-    // poll for result
     return waitForOperationCompletion(projectId, op.getName(), op.getZone(), timeout);
   }
 

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -52,7 +52,7 @@ import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 
 /**
- * Client for communicating with the Google Compute API
+ * Client for communicating with the Google Compute API.
  *
  * @see <a href="https://cloud.google.com/compute/">Compute Engine</a>
  */
@@ -98,7 +98,7 @@ public class ComputeClient {
    * @return A sorted list of available {@link Region}s. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of regions.
    */
-  public List<Region> getRegions(final String projectId) throws IOException {
+  public List<Region> listRegions(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listRegions(projectId),
@@ -114,7 +114,7 @@ public class ComputeClient {
    * @return A list of available {@link Zone}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of zones.
    */
-  public List<Zone> getZones(final String projectId, final String regionLink) throws IOException {
+  public List<Zone> listZones(final String projectId, final String regionLink) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(regionLink));
     return processResourceList(
@@ -131,7 +131,7 @@ public class ComputeClient {
    * @return A list of available {@link MachineType}s sorted by name. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<MachineType> getMachineTypes(final String projectId, final String zoneLink)
+  public List<MachineType> listMachineTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -149,7 +149,7 @@ public class ComputeClient {
    * @return A sorted list of strings with the available CPU platforms.
    * @throws IOException An error occurred attempting to get the list of CPU platforms.
    */
-  public List<String> getCpuPlatforms(final String projectId, final String zoneLink)
+  public List<String> listCpuPlatforms(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -166,7 +166,7 @@ public class ComputeClient {
    * @return A sorted list of available {@link DiskType}s. Deprecated disks are excluded.
    * @throws IOException An error occurred attempting to get the list of disk types.
    */
-  public List<DiskType> getDiskTypes(final String projectId, final String zoneLink)
+  public List<DiskType> listDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -185,7 +185,7 @@ public class ComputeClient {
    *     excluded.
    * @throws IOException An error occurred attempting to get the list of disk types.
    */
-  public List<DiskType> getBootDiskTypes(final String projectId, final String zoneLink)
+  public List<DiskType> listBootDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -203,7 +203,7 @@ public class ComputeClient {
    * @return A list of available {@link Image}s. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of images.
    */
-  public List<Image> getImages(final String projectId) throws IOException {
+  public List<Image> listImages(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listImages(projectId),
@@ -234,7 +234,7 @@ public class ComputeClient {
    *     excluded.
    * @throws IOException An error occurred attempting to get the list of accelerator types.
    */
-  public List<AcceleratorType> getAcceleratorTypes(final String projectId, final String zoneLink)
+  public List<AcceleratorType> listAcceleratorTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -251,7 +251,7 @@ public class ComputeClient {
    * @return A list of available {@link Network}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of networks.
    */
-  public List<Network> getNetworks(final String projectId) throws IOException {
+  public List<Network> listNetworks(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listNetworks(projectId), Comparator.comparing(Network::getName));
@@ -266,7 +266,7 @@ public class ComputeClient {
    * @return A list of available {@link Subnetwork}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<Subnetwork> getSubnetworks(
+  public List<Subnetwork> listSubnetworks(
       final String projectId, final String networkLink, final String regionLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -279,7 +279,8 @@ public class ComputeClient {
   }
 
   /**
-   * Inserts the provided instance into the given project.
+   * Inserts the provided instance into the given project. This method does not block on the
+   * completion of the operation.
    *
    * @param projectId The ID of the project where the instance will reside.
    * @param templateLink A self link to an instance template that may be optionally specified to use
@@ -302,7 +303,8 @@ public class ComputeClient {
   }
 
   /**
-   * Deletes the {@link Instance} specified with the given ID in the project and zone.
+   * Deletes the {@link Instance} specified with the given ID in the project and zone. This method
+   * does not block on the completion of the operation.
    *
    * @param projectId The ID of the project where the instance resides.
    * @param zoneLink The self link of the zone where the instance resides.
@@ -310,7 +312,7 @@ public class ComputeClient {
    * @return The deletion {@link Operation} for tracking the status of deleting the instance.
    * @throws IOException There was an error attempting to delete the instance.
    */
-  public Operation terminateInstance(
+  public Operation terminateInstanceAsync(
       final String projectId, final String zoneLink, final String instanceId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -320,7 +322,7 @@ public class ComputeClient {
 
   /**
    * Deletes the {@link Instance} specified with the given ID in the project and zone if it has the
-   * provided status.
+   * provided status. This method does not block on the completion of the operation.
    *
    * @param projectId The ID of the project where the instance resides.
    * @param zoneLink The self link of the zone where the instance resides.
@@ -331,7 +333,7 @@ public class ComputeClient {
    * @throws IOException There was an error attempting to get the instance status or delete the
    *     instance.
    */
-  public Optional<Operation> terminateInstanceWithStatus(
+  public Optional<Operation> terminateInstanceWithStatusAsync(
       final String projectId,
       final String zoneLink,
       final String instanceId,
@@ -374,16 +376,16 @@ public class ComputeClient {
    * @return A list of {@link Instance}s.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<Instance> getInstancesWithLabel(
+  public List<Instance> listInstancesWithLabel(
       final String projectId, final Map<String, String> labels) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkNotNull(labels);
     Map<String, InstancesScopedList> result =
         compute.aggregatedListInstances(projectId, buildLabelsFilterString(labels));
     List<Instance> instances = new ArrayList<>();
-    for (InstancesScopedList instancesInZone : result.values()) {
-      if (instancesInZone.getInstances() != null) {
-        instances.addAll(instancesInZone.getInstances());
+    for (InstancesScopedList matchingInstances : result.values()) {
+      if (matchingInstances.getInstances() != null) {
+        instances.addAll(matchingInstances.getInstances());
       }
     }
     return instances;
@@ -405,7 +407,8 @@ public class ComputeClient {
   }
 
   /**
-   * Inserts the provided instance into the given project.
+   * Inserts the provided instance into the given project. This method does not block on the
+   * completion of the operation.
    *
    * @param projectId The ID of the project where the instance template will reside.
    * @param instanceTemplate An {@link InstanceTemplate} to insert.
@@ -413,7 +416,7 @@ public class ComputeClient {
    *     template.
    * @throws IOException There was an error attempting to insert the instance template.
    */
-  public Operation insertTemplate(final String projectId, InstanceTemplate instanceTemplate)
+  public Operation insertTemplateAsync(final String projectId, InstanceTemplate instanceTemplate)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkNotNull(instanceTemplate);
@@ -421,7 +424,8 @@ public class ComputeClient {
   }
 
   /**
-   * Deletes the {@link InstanceTemplate} with the given name in the given project.
+   * Deletes the {@link InstanceTemplate} with the given name in the given project. This method does
+   * not block on the completion of the operation.
    *
    * @param projectId The ID of the project where the instance template resides.
    * @param templateName The name of the instance template to delete.
@@ -429,7 +433,7 @@ public class ComputeClient {
    *     template.
    * @throws IOException There was an error attempting to delete the instance template.
    */
-  public Operation deleteTemplate(final String projectId, final String templateName)
+  public Operation deleteTemplateAsync(final String projectId, final String templateName)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(templateName));
@@ -443,7 +447,7 @@ public class ComputeClient {
    * @return A list of available {@link InstanceTemplate}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of instance templates.
    */
-  public List<InstanceTemplate> getTemplates(final String projectId) throws IOException {
+  public List<InstanceTemplate> listTemplates(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listInstanceTemplates(projectId), Comparator.comparing(InstanceTemplate::getName));
@@ -453,14 +457,14 @@ public class ComputeClient {
    * Creates persistent disk snapshot for Compute Engine instance. This method blocks until the
    * operation completes.
    *
-   * @param projectId Google cloud project id (e.g. my-project).
+   * @param projectId The ID of the project where instance resides.
    * @param zoneLink Self link of the instance's zone.
    * @param instanceId Name of the instance whose disks to take a snapshot of.
    * @param timeout The number of milliseconds to wait for snapshot creation.
    * @throws IOException If an error occured in snapshot creation or in retrieving the instance.
    * @throws InterruptedException If snapshot creation is interrupted.
    */
-  public void createSnapshot(
+  public void createSnapshotSync(
       final String projectId, final String zoneLink, final String instanceId, final long timeout)
       throws IOException, InterruptedException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -484,7 +488,7 @@ public class ComputeClient {
                 .wrap(
                     disk -> {
                       try {
-                        createSnapshotForDisk(
+                        createSnapshotForDiskSync(
                             projectId, zoneName, nameFromSelfLink(disk.getSource()), timeout);
                       } catch (IOException ioe) {
                         LOGGER.log(Level.WARNING, "Error in creating snapshot.", ioe);
@@ -499,16 +503,17 @@ public class ComputeClient {
   }
 
   /**
-   * Given a disk's name, create a snapshot for said disk.
+   * Given a disk's name, create a snapshot for said disk. This method blocks until the operation
+   * complete.
    *
-   * @param projectId Google cloud project id.
+   * @param projectId The ID of the project where the disk resides.
    * @param zoneName Zone of disk.
    * @param diskName Name of disk to create a snapshot for.
    * @param timeout The number of milliseconds to wait for snapshot creation.
    * @throws IOException If an error occured in snapshot creation.
    * @throws InterruptedException If snapshot creation is interrupted.
    */
-  public Operation.Error createSnapshotForDisk(
+  public Operation.Error createSnapshotForDiskSync(
       final String projectId, final String zoneName, final String diskName, final long timeout)
       throws IOException, InterruptedException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -526,11 +531,11 @@ public class ComputeClient {
   /**
    * Deletes persistent disk snapshot. Does not block.
    *
-   * @param projectId Google cloud project id.
+   * @param projectId The ID of the project where the snapshot resides.
    * @param snapshotName Name of the snapshot to be deleted.
    * @throws IOException If an error occurred in deleting the snapshot.
    */
-  public Operation deleteSnapshot(final String projectId, final String snapshotName)
+  public Operation deleteSnapshotAsync(final String projectId, final String snapshotName)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(snapshotName));
@@ -538,9 +543,9 @@ public class ComputeClient {
   }
 
   /**
-   * Returns snapshot with name snapshotName
+   * Returns snapshot with name snapshotName.
    *
-   * @param projectId Google cloud project id.
+   * @param projectId The ID of the project where the project resides.
    * @param snapshotName Name of the snapshot to get.
    * @return Snapshot object with given snapshotName. Null if not found.
    * @throws IOException If an error occurred in retrieving the snapshot.
@@ -581,7 +586,7 @@ public class ComputeClient {
    * @throws IOException If there was an error retrieving the instance.
    * @throws InterruptedException If the operation to set metadata timed out.
    */
-  public Operation.Error appendInstanceMetadata(
+  public Operation.Error appendInstanceMetadataSync(
       final String projectId,
       final String zoneLink,
       final String instanceId,
@@ -638,7 +643,7 @@ public class ComputeClient {
           // Awaitility requires a function without arguments, so cannot use helper method here.
           .until(
               () -> {
-                LOGGER.log(Level.FINE, "Waiting for operation " + operationId + " to complete..");
+                LOGGER.log(Level.FINE, "Waiting for operation " + operationId + " to complete.");
                 try {
                   Operation op = getZoneOperation(projectId, zoneLink, operationId);
                   // Store the error here.
@@ -650,7 +655,7 @@ public class ComputeClient {
                 }
               });
     } catch (ConditionTimeoutException e) {
-      throw new InterruptedException("Timed out waiting for operation to complete");
+      throw new InterruptedException("Timed out waiting for operation to complete.");
     }
     return operation.getError();
   }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -263,17 +263,17 @@ public class ComputeClient {
     return compute.getInstanceTemplate(projectId, templateName);
   }
 
-  public void insertTemplate(final String projectId, InstanceTemplate instanceTemplate)
+  public Operation insertTemplate(final String projectId, InstanceTemplate instanceTemplate)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkNotNull(instanceTemplate);
-    compute.insertInstanceTemplate(projectId, instanceTemplate);
+    return compute.insertInstanceTemplate(projectId, instanceTemplate);
   }
 
-  public void deleteTemplate(final String projectId, final String templateName) throws IOException {
+  public Operation deleteTemplate(final String projectId, final String templateName) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(templateName));
-    compute.deleteInstanceTemplate(projectId, templateName);
+    return compute.deleteInstanceTemplate(projectId, templateName);
   }
 
   public List<InstanceTemplate> getTemplates(final String projectId) throws IOException {
@@ -341,7 +341,7 @@ public class ComputeClient {
    * @throws IOException If an error occured in snapshot creation.
    * @throws InterruptedException If snapshot creation is interrupted.
    */
-  public void createSnapshotForDisk(
+  public Operation.Error createSnapshotForDisk(
       final String projectId, final String zoneName, final String diskName, final long timeout)
       throws IOException, InterruptedException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -353,7 +353,7 @@ public class ComputeClient {
 
     Operation op = compute.createDiskSnapshot(projectId, zoneName, diskName, snapshot);
     // poll for result
-    waitForOperationCompletion(projectId, op, timeout);
+    return waitForOperationCompletion(projectId, op, timeout);
   }
 
   /**
@@ -363,10 +363,10 @@ public class ComputeClient {
    * @param snapshotName Name of the snapshot to be deleted.
    * @throws IOException If an error occurred in deleting the snapshot.
    */
-  public void deleteSnapshot(final String projectId, final String snapshotName) throws IOException {
+  public Operation deleteSnapshot(final String projectId, final String snapshotName) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(snapshotName));
-    compute.deleteSnapshot(projectId, snapshotName);
+    return compute.deleteSnapshot(projectId, snapshotName);
   }
 
   /**

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -51,13 +51,13 @@ import java.util.logging.Logger;
  * @see <a href="https://cloud.google.com/compute/">Cloud Engine</a>
  */
 public class ComputeClient {
-  private Compute compute;
-
   private static final Logger LOGGER = Logger.getLogger(ComputeClient.class.getName());
   private static final long SNAPSHOT_TIMEOUT_MILLISECONDS = TimeUnit.MINUTES.toMillis(10);
 
+  private final Compute compute;
+
   public ComputeClient(Compute compute) {
-    setCompute(compute);
+    this.compute = compute;
   }
 
   public static String nameFromSelfLink(String selfLink) {
@@ -91,10 +91,6 @@ public class ComputeClient {
       }
     }
     return winner;
-  }
-
-  public void setCompute(Compute compute) {
-    this.compute = compute;
   }
 
   /**

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -54,7 +54,7 @@ import org.awaitility.core.ConditionTimeoutException;
 /**
  * Client for communicating with the Google Compute API
  *
- * @see <a href="https://cloud.google.com/compute/">Cloud Engine</a>
+ * @see <a href="https://cloud.google.com/compute/">Compute Engine</a>
  */
 public class ComputeClient {
   private static final Logger LOGGER = Logger.getLogger(ComputeClient.class.getName());
@@ -65,6 +65,15 @@ public class ComputeClient {
     this.compute = compute;
   }
 
+  /**
+   * Helper method for merging lists of {@link Metadata.Items}.
+   *
+   * @param winner The list of items that will be returned in the final result.
+   * @param loser The list of items that will be returned in the final result, unless an item has
+   *     the same key as an item in {@param winner}, in which case the item from winner will be
+   *     used.
+   * @return The combined list of items from the input lists.
+   */
   public static List<Metadata.Items> mergeMetadataItems(
       final List<Metadata.Items> winner, final List<Metadata.Items> loser) {
     if (loser == null) {
@@ -83,8 +92,11 @@ public class ComputeClient {
   }
 
   /**
-   * @return
-   * @throws IOException
+   * Retrieves the list of {@link Region}s available to the provided project.
+   *
+   * @param projectId The ID of the project to check.
+   * @return A sorted list of available {@link Region}s. Deprecated items are excluded.
+   * @throws IOException An error occurred attempting to get the list of regions.
    */
   public List<Region> getRegions(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -94,6 +106,14 @@ public class ComputeClient {
         Comparator.comparing(Region::getName));
   }
 
+  /**
+   * Retrieves the list of zones available to the project in the given region.
+   *
+   * @param projectId The ID of the project to check.
+   * @param regionLink The self link of the region to check.
+   * @return A list of available {@link Zone}s sorted by name.
+   * @throws IOException An error occurred attempting to get the list of zones.
+   */
   public List<Zone> getZones(final String projectId, final String regionLink) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(regionLink));
@@ -103,6 +123,14 @@ public class ComputeClient {
         Comparator.comparing(Zone::getName));
   }
 
+  /**
+   * Retrieves the list of {@link MachineType}s available for the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @return A list of available {@link MachineType}s sorted by name. Deprecated items are excluded.
+   * @throws IOException An error occurred attempting to get the list of machine types.
+   */
   public List<MachineType> getMachineTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -113,6 +141,14 @@ public class ComputeClient {
         Comparator.comparing(MachineType::getName));
   }
 
+  /**
+   * Retrieves the list of CPU Platforms available for the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @return A sorted list of strings with the available CPU platforms.
+   * @throws IOException An error occurred attempting to get the list of CPU platforms.
+   */
   public List<String> getCpuPlatforms(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -122,6 +158,14 @@ public class ComputeClient {
         String::compareTo);
   }
 
+  /**
+   * Retrieves the list of {@link DiskType}s available for the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @return A sorted list of available {@link DiskType}s. Deprecated disks are excluded.
+   * @throws IOException An error occurred attempting to get the list of disk types.
+   */
   public List<DiskType> getDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -132,6 +176,15 @@ public class ComputeClient {
         Comparator.comparing(DiskType::getName));
   }
 
+  /**
+   * Retrieves the list of Boot {@link DiskType}s available for the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @return A list of available {@link DiskType}s sorted by name. Deprecated and local disks are
+   *     excluded.
+   * @throws IOException An error occurred attempting to get the list of disk types.
+   */
   public List<DiskType> getBootDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -143,6 +196,13 @@ public class ComputeClient {
         Comparator.comparing(DiskType::getName));
   }
 
+  /**
+   * Retrieves the list of {@link Image}s available for the given project.
+   *
+   * @param projectId The ID of the project to check.
+   * @return A list of available {@link Image}s. Deprecated items are excluded.
+   * @throws IOException An error occurred attempting to get the list of images.
+   */
   public List<Image> getImages(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
@@ -151,12 +211,29 @@ public class ComputeClient {
         Comparator.comparing(Image::getName));
   }
 
+  /**
+   * Retrieves the {@link Image} with the given name in the given project.
+   *
+   * @param projectId The ID of the project to check.
+   * @param imageName The name of the image to retrieve.
+   * @return The {@link Image} to retrieve.
+   * @throws IOException An error occurred attempting to get the image.
+   */
   public Image getImage(final String projectId, final String imageName) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(imageName));
     return compute.getImage(projectId, imageName);
   }
 
+  /**
+   * Retrieves the list of {@link AcceleratorType}s available for the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @return A list of available {@link AcceleratorType}s sorted by name. Deprecated items are
+   *     excluded.
+   * @throws IOException An error occurred attempting to get the list of accelerator types.
+   */
   public List<AcceleratorType> getAcceleratorTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -167,12 +244,28 @@ public class ComputeClient {
         Comparator.comparing(AcceleratorType::getName));
   }
 
+  /**
+   * Retrieves the list of {@link Network}s available for the given project.
+   *
+   * @param projectId The ID of the project to check.
+   * @return A list of available {@link Network}s sorted by name.
+   * @throws IOException An error occurred attempting to get the list of networks.
+   */
   public List<Network> getNetworks(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listNetworks(projectId), Comparator.comparing(Network::getName));
   }
 
+  /**
+   * Retrieves the list of {@link Subnetwork}s of the network in the given project and region.
+   *
+   * @param projectId The ID of the project to check.
+   * @param networkLink The self link of the network to check.
+   * @param regionLink The self link of the region to check.
+   * @return A list of available {@link Subnetwork}s sorted by name.
+   * @throws IOException An error occurred attempting to get the list of machine types.
+   */
   public List<Subnetwork> getSubnetworks(
       final String projectId, final String networkLink, final String regionLink)
       throws IOException {
@@ -185,6 +278,16 @@ public class ComputeClient {
         Comparator.comparing(Subnetwork::getName));
   }
 
+  /**
+   * Inserts the provided instance into the given project.
+   *
+   * @param projectId The ID of the project where the instance will reside.
+   * @param templateLink A self link to an instance template that may be optionally specified to use
+   *     the configuration for that template when creating the instance.
+   * @param instance An {@link Instance} to insert. The instance should specify a zone at minimum.
+   * @return The insert {@link Operation} for tracking the status of inserting the instance.
+   * @throws IOException There was an error attempting to insert the instance.
+   */
   public Operation insertInstance(
       final String projectId, final Optional<String> templateLink, final Instance instance)
       throws IOException {
@@ -198,6 +301,15 @@ public class ComputeClient {
     return compute.insertInstance(projectId, zone, instance);
   }
 
+  /**
+   * Deletes the {@link Instance} specified with the given ID in the project and zone.
+   *
+   * @param projectId The ID of the project where the instance resides.
+   * @param zoneLink The self link of the zone where the instance resides.
+   * @param instanceId The ID of the instance to delete.
+   * @return The deletion {@link Operation} for tracking the status of deleting the instance.
+   * @throws IOException There was an error attempting to delete the instance.
+   */
   public Operation terminateInstance(
       final String projectId, final String zoneLink, final String instanceId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -206,12 +318,25 @@ public class ComputeClient {
     return compute.deleteInstance(projectId, nameFromSelfLink(zoneLink), instanceId);
   }
 
-  public Operation terminateInstanceWithStatus(
+  /**
+   * Deletes the {@link Instance} specified with the given ID in the project and zone if it has the
+   * provided status.
+   *
+   * @param projectId The ID of the project where the instance resides.
+   * @param zoneLink The self link of the zone where the instance resides.
+   * @param instanceId The ID of the instance to delete.
+   * @param desiredStatus The status that the instance must have to be deleted.
+   * @return The deletion {@link Operation} for tracking the status of deleting the instance, or
+   *     empty if the instance did not have the desired status.
+   * @throws IOException There was an error attempting to get the instance status or delete the
+   *     instance.
+   */
+  public Optional<Operation> terminateInstanceWithStatus(
       final String projectId,
       final String zoneLink,
       final String instanceId,
       final String desiredStatus)
-      throws IOException, InterruptedException {
+      throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(instanceId));
@@ -219,11 +344,20 @@ public class ComputeClient {
     final String zoneName = nameFromSelfLink(zoneLink);
     Instance instance = compute.getInstance(projectId, zoneName, instanceId);
     if (instance.getStatus().equals(desiredStatus)) {
-      return compute.deleteInstance(projectId, zoneName, instanceId);
+      return Optional.of(compute.deleteInstance(projectId, zoneName, instanceId));
     }
-    return null;
+    return Optional.empty();
   }
 
+  /**
+   * Retrieves the {@link Instance} with the given ID in the given project and zone.
+   *
+   * @param projectId The ID of the project to check.
+   * @param zoneLink The self link of the zone to check.
+   * @param instanceId The ID of the instance to retrieve.
+   * @return The specified {@link Instance}.
+   * @throws IOException An error occurred attempting to get the instance.
+   */
   public Instance getInstance(
       final String projectId, final String zoneLink, final String instanceId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -233,12 +367,12 @@ public class ComputeClient {
   }
 
   /**
-   * Return all instances that contain the given labels
+   * Retrieves the list of {@link Instance}s with the provided labels in the project.
    *
-   * @param projectId
-   * @param labels
-   * @return
-   * @throws IOException
+   * @param projectId The ID of the project to check.
+   * @param labels A map of labels.
+   * @return A list of {@link Instance}s.
+   * @throws IOException An error occurred attempting to get the list of machine types.
    */
   public List<Instance> getInstancesWithLabel(
       final String projectId, final Map<String, String> labels) throws IOException {
@@ -255,6 +389,14 @@ public class ComputeClient {
     return instances;
   }
 
+  /**
+   * Retrieves the {@link InstanceTemplate} with the given name in the project.
+   *
+   * @param projectId The ID of the project to check.
+   * @param templateName The name of the template to retrieve.
+   * @return The specified {@link InstanceTemplate}.
+   * @throws IOException An error occurred attempting to get the instance template.
+   */
   public InstanceTemplate getTemplate(final String projectId, final String templateName)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -262,6 +404,15 @@ public class ComputeClient {
     return compute.getInstanceTemplate(projectId, templateName);
   }
 
+  /**
+   * Inserts the provided instance into the given project.
+   *
+   * @param projectId The ID of the project where the instance template will reside.
+   * @param instanceTemplate An {@link InstanceTemplate} to insert.
+   * @return The insert {@link Operation} for tracking the status of inserting the instance
+   *     template.
+   * @throws IOException There was an error attempting to insert the instance template.
+   */
   public Operation insertTemplate(final String projectId, InstanceTemplate instanceTemplate)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -269,6 +420,15 @@ public class ComputeClient {
     return compute.insertInstanceTemplate(projectId, instanceTemplate);
   }
 
+  /**
+   * Deletes the {@link InstanceTemplate} with the given name in the given project.
+   *
+   * @param projectId The ID of the project where the instance template resides.
+   * @param templateName The name of the instance template to delete.
+   * @return The deletion {@link Operation} for tracking the status of deleting the instance
+   *     template.
+   * @throws IOException There was an error attempting to delete the instance template.
+   */
   public Operation deleteTemplate(final String projectId, final String templateName)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -276,6 +436,13 @@ public class ComputeClient {
     return compute.deleteInstanceTemplate(projectId, templateName);
   }
 
+  /**
+   * Retrieves the list of {@link InstanceTemplate}s available for the given project.
+   *
+   * @param projectId The ID of the project to check.
+   * @return A list of available {@link InstanceTemplate}s sorted by name.
+   * @throws IOException An error occurred attempting to get the list of instance templates.
+   */
   public List<InstanceTemplate> getTemplates(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -75,7 +75,7 @@ public class ComputeClient {
    *     used.
    * @return The combined list of items from the input lists.
    */
-  public static List<Metadata.Items> mergeMetadataItems(
+  public static ImmutableList<Metadata.Items> mergeMetadataItems(
       final List<Metadata.Items> winner, final List<Metadata.Items> loser) {
     if (loser == null) {
       return ImmutableList.copyOf(winner);
@@ -99,7 +99,7 @@ public class ComputeClient {
    * @return A sorted list of available {@link Region}s. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of regions.
    */
-  public List<Region> listRegions(final String projectId) throws IOException {
+  public ImmutableList<Region> listRegions(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listRegions(projectId),
@@ -115,7 +115,8 @@ public class ComputeClient {
    * @return A list of available {@link Zone}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of zones.
    */
-  public List<Zone> listZones(final String projectId, final String regionLink) throws IOException {
+  public ImmutableList<Zone> listZones(final String projectId, final String regionLink)
+      throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(regionLink));
     return processResourceList(
@@ -132,7 +133,7 @@ public class ComputeClient {
    * @return A list of available {@link MachineType}s sorted by name. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<MachineType> listMachineTypes(final String projectId, final String zoneLink)
+  public ImmutableList<MachineType> listMachineTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -150,7 +151,7 @@ public class ComputeClient {
    * @return A sorted list of strings with the available CPU platforms.
    * @throws IOException An error occurred attempting to get the list of CPU platforms.
    */
-  public List<String> listCpuPlatforms(final String projectId, final String zoneLink)
+  public ImmutableList<String> listCpuPlatforms(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -167,7 +168,7 @@ public class ComputeClient {
    * @return A sorted list of available {@link DiskType}s. Deprecated disks are excluded.
    * @throws IOException An error occurred attempting to get the list of disk types.
    */
-  public List<DiskType> listDiskTypes(final String projectId, final String zoneLink)
+  public ImmutableList<DiskType> listDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -186,7 +187,7 @@ public class ComputeClient {
    *     excluded.
    * @throws IOException An error occurred attempting to get the list of disk types.
    */
-  public List<DiskType> listBootDiskTypes(final String projectId, final String zoneLink)
+  public ImmutableList<DiskType> listBootDiskTypes(final String projectId, final String zoneLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
@@ -204,7 +205,7 @@ public class ComputeClient {
    * @return A list of available {@link Image}s. Deprecated items are excluded.
    * @throws IOException An error occurred attempting to get the list of images.
    */
-  public List<Image> listImages(final String projectId) throws IOException {
+  public ImmutableList<Image> listImages(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listImages(projectId),
@@ -235,8 +236,8 @@ public class ComputeClient {
    *     excluded.
    * @throws IOException An error occurred attempting to get the list of accelerator types.
    */
-  public List<AcceleratorType> listAcceleratorTypes(final String projectId, final String zoneLink)
-      throws IOException {
+  public ImmutableList<AcceleratorType> listAcceleratorTypes(
+      final String projectId, final String zoneLink) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneLink));
     return processResourceList(
@@ -252,7 +253,7 @@ public class ComputeClient {
    * @return A list of available {@link Network}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of networks.
    */
-  public List<Network> listNetworks(final String projectId) throws IOException {
+  public ImmutableList<Network> listNetworks(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listNetworks(projectId), Comparator.comparing(Network::getName));
@@ -267,7 +268,7 @@ public class ComputeClient {
    * @return A list of available {@link Subnetwork}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<Subnetwork> listSubnetworks(
+  public ImmutableList<Subnetwork> listSubnetworks(
       final String projectId, final String networkLink, final String regionLink)
       throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
@@ -377,7 +378,7 @@ public class ComputeClient {
    * @return A list of {@link Instance}s.
    * @throws IOException An error occurred attempting to get the list of machine types.
    */
-  public List<Instance> listInstancesWithLabel(
+  public ImmutableList<Instance> listInstancesWithLabel(
       final String projectId, final Map<String, String> labels) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkNotNull(labels);
@@ -389,7 +390,7 @@ public class ComputeClient {
         instances.addAll(matchingInstances.getInstances());
       }
     }
-    return instances;
+    return ImmutableList.copyOf(instances);
   }
 
   /**
@@ -448,7 +449,7 @@ public class ComputeClient {
    * @return A list of available {@link InstanceTemplate}s sorted by name.
    * @throws IOException An error occurred attempting to get the list of instance templates.
    */
-  public List<InstanceTemplate> listTemplates(final String projectId) throws IOException {
+  public ImmutableList<InstanceTemplate> listTemplates(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         compute.listInstanceTemplates(projectId), Comparator.comparing(InstanceTemplate::getName));

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -58,6 +58,7 @@ import org.awaitility.core.ConditionTimeoutException;
  */
 public class ComputeClient {
   private static final Logger LOGGER = Logger.getLogger(ComputeClient.class.getName());
+  private static final long POLLING_INTERVAL = 5 * 1000;
 
   private final ComputeWrapper compute;
 
@@ -638,7 +639,7 @@ public class ComputeClient {
     Operation operation = new Operation();
     try {
       Awaitility.await()
-          .pollInterval(5 * 1000, TimeUnit.MILLISECONDS)
+          .pollInterval(POLLING_INTERVAL, TimeUnit.MILLISECONDS)
           .timeout(timeout, TimeUnit.MILLISECONDS)
           // Awaitility requires a function without arguments, so cannot use helper method here.
           .until(

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeClient.java
@@ -21,7 +21,6 @@ import static com.google.graphite.platforms.plugin.client.util.ClientUtil.nameFr
 import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
 
 import com.diffplug.common.base.Errors;
-import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.AcceleratorType;
 import com.google.api.services.compute.model.DeprecationStatus;
 import com.google.api.services.compute.model.DiskType;
@@ -62,8 +61,8 @@ public class ComputeClient {
 
   private final ComputeWrapper compute;
 
-  ComputeClient(final Compute compute) {
-    this.compute = new ComputeWrapper(compute);
+  ComputeClient(final ComputeWrapper compute) {
+    this.compute = compute;
   }
 
   public static List<Metadata.Items> mergeMetadataItems(
@@ -270,7 +269,8 @@ public class ComputeClient {
     return compute.insertInstanceTemplate(projectId, instanceTemplate);
   }
 
-  public Operation deleteTemplate(final String projectId, final String templateName) throws IOException {
+  public Operation deleteTemplate(final String projectId, final String templateName)
+      throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(templateName));
     return compute.deleteInstanceTemplate(projectId, templateName);
@@ -363,7 +363,8 @@ public class ComputeClient {
    * @param snapshotName Name of the snapshot to be deleted.
    * @throws IOException If an error occurred in deleting the snapshot.
    */
-  public Operation deleteSnapshot(final String projectId, final String snapshotName) throws IOException {
+  public Operation deleteSnapshot(final String projectId, final String snapshotName)
+      throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(snapshotName));
     return compute.deleteSnapshot(projectId, snapshotName);

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeWrapper.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeWrapper.java
@@ -1,0 +1,137 @@
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.AcceleratorType;
+import com.google.api.services.compute.model.DiskType;
+import com.google.api.services.compute.model.Image;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceTemplate;
+import com.google.api.services.compute.model.InstancesScopedList;
+import com.google.api.services.compute.model.MachineType;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Region;
+import com.google.api.services.compute.model.Snapshot;
+import com.google.api.services.compute.model.Subnetwork;
+import com.google.api.services.compute.model.Zone;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/*
+ * Internal use only. Wraps chained methods with direct calls for readability and mocking. The lack
+ * of final parameters or parameter checking is intended, this is purely for wrapping.
+ */
+class ComputeWrapper {
+  private final Compute compute;
+
+  ComputeWrapper(Compute compute) {
+    this.compute = compute;
+  }
+
+  List<Region> listRegions(String projectId) throws IOException {
+    return compute.regions().list(projectId).execute().getItems();
+  }
+
+  Zone getZone(String projectId, String zone) throws IOException {
+    return compute.zones().get(projectId, zone).execute();
+  }
+
+  List<Zone> listZones(String projectId) throws IOException {
+    return compute.zones().list(projectId).execute().getItems();
+  }
+
+  List<MachineType> listMachineTypes(String projectId, String zone) throws IOException {
+    return compute.machineTypes().list(projectId, zone).execute().getItems();
+  }
+
+  List<DiskType> listDiskTypes(String projectId, String zone) throws IOException {
+    return compute.diskTypes().list(projectId, zone).execute().getItems();
+  }
+
+  Image getImage(String projectId, String image) throws IOException {
+    return compute.images().get(projectId, image).execute();
+  }
+
+  List<Image> listImages(String projectId) throws IOException {
+    return compute.images().list(projectId).execute().getItems();
+  }
+
+  List<AcceleratorType> listAcceleratorTypes(String projectId, String zone) throws IOException {
+    return compute.acceleratorTypes().list(projectId, zone).execute().getItems();
+  }
+
+  List<Network> listNetworks(String projectId) throws IOException {
+    return compute.networks().list(projectId).execute().getItems();
+  }
+
+  List<Subnetwork> listSubnetworks(String projectId, String region) throws IOException {
+    return compute.subnetworks().list(projectId, region).execute().getItems();
+  }
+
+  Operation insertInstance(String projectId, String zone, Instance instance) throws IOException {
+    return compute.instances().insert(projectId, zone, instance).execute();
+  }
+
+  Operation insertInstanceWithTemplate(
+      String projectId, String zone, Instance instance, String template) throws IOException {
+    return compute
+        .instances()
+        .insert(projectId, zone, instance)
+        .setSourceInstanceTemplate(template)
+        .execute();
+  }
+
+  Operation deleteInstance(String projectId, String zone, String instanceId) throws IOException {
+    return compute.instances().delete(projectId, zone, instanceId).execute();
+  }
+
+  Operation setInstanceMetadata(String projectId, String zone, String instanceId, Metadata metadata)
+      throws IOException {
+    return compute.instances().setMetadata(projectId, zone, instanceId, metadata).execute();
+  }
+
+  Instance getInstance(String projectId, String zone, String instanceId) throws IOException {
+    return compute.instances().get(projectId, zone, instanceId).execute();
+  }
+
+  Map<String, InstancesScopedList> aggregatedListInstances(String projectId, String filter)
+      throws IOException {
+    return compute.instances().aggregatedList(projectId).setFilter(filter).execute().getItems();
+  }
+
+  InstanceTemplate getInstanceTemplate(String projectId, String templateName) throws IOException {
+    return compute.instanceTemplates().get(projectId, templateName).execute();
+  }
+
+  List<InstanceTemplate> listInstanceTemplates(String projectId) throws IOException {
+    return compute.instanceTemplates().list(projectId).execute().getItems();
+  }
+
+  Operation insertInstanceTemplate(String projectId, InstanceTemplate instanceTemplate)
+      throws IOException {
+    return compute.instanceTemplates().insert(projectId, instanceTemplate).execute();
+  }
+
+  Operation deleteInstanceTemplate(String projectId, String templateName) throws IOException {
+    return compute.instanceTemplates().delete(projectId, templateName).execute();
+  }
+
+  Operation createDiskSnapshot(String projectId, String zone, String disk, Snapshot snapshot)
+      throws IOException {
+    return compute.disks().createSnapshot(projectId, zone, disk, snapshot).execute();
+  }
+
+  Operation deleteSnapshot(String projectId, String snapshotName) throws IOException {
+    return compute.snapshots().delete(projectId, snapshotName).execute();
+  }
+
+  Snapshot getSnapshot(String projectId, String snapshotName) throws IOException {
+    return compute.snapshots().get(projectId, snapshotName).execute();
+  }
+
+  Operation getZoneOperation(String projectId, String zone, String operationId) throws IOException {
+    return compute.zoneOperations().get(projectId, zone, operationId).execute();
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeWrapper.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ComputeWrapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.graphite.platforms.plugin.client;
 
 import com.google.api.services.compute.Compute;

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -18,7 +18,7 @@ import com.google.api.services.container.Container;
 import com.google.api.services.container.model.Cluster;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
+import com.google.graphite.platforms.plugin.client.util.ClientUtil;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -81,11 +81,7 @@ public class ContainerClient {
             .list(toApiParent(projectId))
             .execute()
             .getClusters();
-    if (clusters == null) {
-      return ImmutableList.of();
-    }
-    clusters.sort(Comparator.comparing(Cluster::getName));
-    return ImmutableList.copyOf(clusters);
+    return ClientUtil.processResourceList(clusters, Comparator.comparing(Cluster::getName));
   }
 
   private static String toApiName(String projectId, String location, String clusterName) {

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -66,7 +66,7 @@ public class ContainerClient {
    *
    * @param projectId The ID of the project the clusters reside in.
    * @return The retrieved list of {@link Cluster} objects.
-   * @throws IOException When an error occurred attempting to get the cluster.
+   * @throws IOException When an error occurred attempting to get the list of clusters.
    */
   public List<Cluster> listAllClusters(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.container.Container;
+import com.google.api.services.container.model.Cluster;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Client for communicating with the Google GKE API.
+ *
+ * @see <a href="https://cloud.google.com/kubernetes-engine/docs/reference/rest/">Kubernetes
+ *     Engine</a>
+ */
+public class ContainerClient {
+  private static final String LOCATION_WILDCARD = "-";
+  private final Container container;
+
+  /**
+   * Constructs a new {@link ContainerClient} instance.
+   *
+   * @param container The {@link Container} instance this class will utilize for interacting with
+   *     the GKE API.
+   */
+  public ContainerClient(Container container) {
+    this.container = Preconditions.checkNotNull(container);
+  }
+
+  /**
+   * Retrieves a {@link Cluster} from the container client.
+   *
+   * @param projectId The ID of the project the cluster resides in.
+   * @param location The location of the cluster.
+   * @param cluster The name of the cluster.
+   * @return The retrieved {@link Cluster}.
+   * @throws IOException When an error occurred attempting to get the cluster.
+   */
+  public Cluster getCluster(String projectId, String location, String cluster) throws IOException {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
+    return container
+        .projects()
+        .locations()
+        .clusters()
+        .get(toApiName(projectId, location, cluster))
+        .execute();
+  }
+
+  /**
+   * Retrieves a list of all {@link Cluster} objects for the project from the container client.
+   *
+   * @param projectId The ID of the project the clusters reside in.
+   * @return The retrieved list of {@link Cluster} objects.
+   * @throws IOException When an error occurred attempting to get the cluster.
+   */
+  public List<Cluster> listAllClusters(String projectId) throws IOException {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
+    List<Cluster> clusters =
+        container
+            .projects()
+            .locations()
+            .clusters()
+            .list(toApiParent(projectId))
+            .execute()
+            .getClusters();
+    if (clusters == null) {
+      return ImmutableList.of();
+    }
+    clusters.sort(Comparator.comparing(Cluster::getName));
+    return ImmutableList.copyOf(clusters);
+  }
+
+  private static String toApiName(String projectId, String location, String clusterName) {
+    return String.format("projects/%s/locations/%s/clusters/%s", projectId, location, clusterName);
+  }
+
+  private static String toApiParent(String projectId) {
+    return String.format("projects/%s/locations/%s", projectId, LOCATION_WILDCARD);
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class ContainerClient {
   private static final String LOCATION_WILDCARD = "-";
-  private final Container container;
+  private final ContainerWrapper container;
 
   /**
    * Constructs a new {@link ContainerClient} instance.
@@ -40,7 +40,7 @@ public class ContainerClient {
    * @param container The {@link Container} instance this class will utilize for interacting with
    *     the GKE API.
    */
-  public ContainerClient(final Container container) {
+  public ContainerClient(final ContainerWrapper container) {
     this.container = Preconditions.checkNotNull(container);
   }
 
@@ -58,12 +58,7 @@ public class ContainerClient {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    return container
-        .projects()
-        .locations()
-        .clusters()
-        .get(toApiName(projectId, location, cluster))
-        .execute();
+    return container.getCluster(projectId, location, cluster);
   }
 
   /**
@@ -76,22 +71,7 @@ public class ContainerClient {
   public List<Cluster> listAllClusters(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
-        container
-            .projects()
-            .locations()
-            .clusters()
-            .list(toApiParent(projectId))
-            .execute()
-            .getClusters(),
+        container.listClusters(projectId, LOCATION_WILDCARD),
         Comparator.comparing(Cluster::getName));
-  }
-
-  private static String toApiName(
-      final String projectId, final String location, final String clusterName) {
-    return String.format("projects/%s/locations/%s/clusters/%s", projectId, location, clusterName);
-  }
-
-  private static String toApiParent(final String projectId) {
-    return String.format("projects/%s/locations/%s", projectId, LOCATION_WILDCARD);
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -39,7 +39,7 @@ public class ContainerClient {
    * @param container The {@link Container} instance this class will utilize for interacting with
    *     the GKE API.
    */
-  public ContainerClient(Container container) {
+  public ContainerClient(final Container container) {
     this.container = Preconditions.checkNotNull(container);
   }
 
@@ -52,7 +52,8 @@ public class ContainerClient {
    * @return The retrieved {@link Cluster}.
    * @throws IOException When an error occurred attempting to get the cluster.
    */
-  public Cluster getCluster(String projectId, String location, String cluster) throws IOException {
+  public Cluster getCluster(final String projectId, final String location, final String cluster)
+      throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
@@ -71,7 +72,7 @@ public class ContainerClient {
    * @return The retrieved list of {@link Cluster} objects.
    * @throws IOException When an error occurred attempting to get the cluster.
    */
-  public List<Cluster> listAllClusters(String projectId) throws IOException {
+  public List<Cluster> listAllClusters(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     List<Cluster> clusters =
         container
@@ -84,11 +85,12 @@ public class ContainerClient {
     return ClientUtil.processResourceList(clusters, Comparator.comparing(Cluster::getName));
   }
 
-  private static String toApiName(String projectId, String location, String clusterName) {
+  private static String toApiName(
+      final String projectId, final String location, final String clusterName) {
     return String.format("projects/%s/locations/%s/clusters/%s", projectId, location, clusterName);
   }
 
-  private static String toApiParent(String projectId) {
+  private static String toApiParent(final String projectId) {
     return String.format("projects/%s/locations/%s", projectId, LOCATION_WILDCARD);
   }
 }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -14,11 +14,12 @@
 
 package com.google.graphite.platforms.plugin.client;
 
+import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
+
 import com.google.api.services.container.Container;
 import com.google.api.services.container.model.Cluster;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.graphite.platforms.plugin.client.util.ClientUtil;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
@@ -74,15 +75,15 @@ public class ContainerClient {
    */
   public List<Cluster> listAllClusters(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
-    List<Cluster> clusters =
+    return processResourceList(
         container
             .projects()
             .locations()
             .clusters()
             .list(toApiParent(projectId))
             .execute()
-            .getClusters();
-    return ClientUtil.processResourceList(clusters, Comparator.comparing(Cluster::getName));
+            .getClusters(),
+        Comparator.comparing(Cluster::getName));
   }
 
   private static String toApiName(

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerClient.java
@@ -20,9 +20,9 @@ import com.google.api.services.container.Container;
 import com.google.api.services.container.model.Cluster;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.List;
 
 /**
  * Client for communicating with the Google GKE API.
@@ -65,10 +65,10 @@ public class ContainerClient {
    * Retrieves a list of all {@link Cluster} objects for the project from the container client.
    *
    * @param projectId The ID of the project the clusters reside in.
-   * @return The retrieved list of {@link Cluster} objects.
+   * @return The retrieved list of {@link Cluster}s sorted by name.
    * @throws IOException When an error occurred attempting to get the list of clusters.
    */
-  public List<Cluster> listAllClusters(final String projectId) throws IOException {
+  public ImmutableList<Cluster> listAllClusters(final String projectId) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     return processResourceList(
         container.listClusters(projectId, LOCATION_WILDCARD),

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerWrapper.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/ContainerWrapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import com.google.api.services.container.Container;
+import com.google.api.services.container.model.Cluster;
+import java.io.IOException;
+import java.util.List;
+
+/*
+ * Internal use only. Wraps chained methods with direct calls for readability and mocking. The lack
+ * of final parameters or parameter checking is intended, this is purely for wrapping.
+ */
+class ContainerWrapper {
+  private final Container container;
+
+  ContainerWrapper(Container container) {
+    this.container = container;
+  }
+
+  Cluster getCluster(String projectId, String location, String clusterName) throws IOException {
+    return container
+        .projects()
+        .locations()
+        .clusters()
+        .get(toApiName(projectId, location, clusterName))
+        .execute();
+  }
+
+  List<Cluster> listClusters(String projectId, String location) throws IOException {
+    return container
+        .projects()
+        .locations()
+        .clusters()
+        .list(toApiParent(projectId, location))
+        .execute()
+        .getClusters();
+  }
+
+  private static String toApiName(
+      final String projectId, final String location, final String clusterName) {
+    return String.format("projects/%s/locations/%s/clusters/%s", projectId, location, clusterName);
+  }
+
+  private static String toApiParent(final String projectId, final String location) {
+    return String.format("projects/%s/locations/%s", projectId, location);
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client.util;
+
+import com.google.api.client.json.GenericJson;
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/** A library of utility functions for common interactions with the GCP client libraries. */
+public class ClientUtil {
+
+  /**
+   * Given a list of GCP resources, filters the list using the provided filter and sorts according
+   * to the provided comparator.
+   *
+   * @param items A list of GCP resources produced by a GCP client library request.
+   * @param filter A predicate applied to objects in {@param items}. If true for a given object,
+   *     then that object will be kept in the final result.
+   * @param comparator Defines a comparison between any two objects in {@param items} used for
+   *     sorting the result.
+   * @param <T> Any GCP resource type from the GCP client library, extending {@link GenericJson}.
+   * @return An {@link ImmutableList} which is empty if {@param items} is null or empty, and
+   *     otherwise is {@param items} filtered and sorted as described above.
+   */
+  public static <T extends GenericJson> ImmutableList<T> processResourceList(
+      final List<T> items, final Predicate<T> filter, final Comparator<T> comparator) {
+    if (items == null) {
+      return ImmutableList.of();
+    }
+    return ImmutableList.copyOf(
+        items.stream().filter(filter).sorted(comparator).collect(Collectors.toList()));
+  }
+
+  /**
+   * Given a list of GCP resources, sorts according to the provided comparator.
+   *
+   * @param items A list of GCP resources produced by a GCP client library request.
+   * @param comparator Defines a comparison between any two objects in {@param items} used for
+   *     sorting the result.
+   * @param <T> Any GCP resource type from the GCP client library, extending {@link GenericJson}.
+   * @return An {@link ImmutableList} which is empty if {@param items} is null or empty, and
+   *     otherwise is {@param items} filtered and sorted as described above.
+   */
+  public static <T extends GenericJson> ImmutableList<T> processResourceList(
+      final List<T> items, final Comparator<T> comparator) {
+    return processResourceList(items, n -> true, comparator);
+  }
+
+  /**
+   * Removes the prefix information from the provided self link returning only the name.
+   *
+   * @param selfLink A GCP resource self link, e.g. for an instance:
+   *     "projects/exampleproject/zones/us-west1-a/instances/example"
+   * @return The name of the resource referenced by the self-link, i.e. "example".
+   */
+  public static String nameFromSelfLink(final String selfLink) {
+    return selfLink.substring(selfLink.lastIndexOf("/") + 1);
+  }
+
+  /**
+   * Converts a map of GCP labels into the format required to filter a request with these labels.
+   *
+   * @param labels A map of key:value GCP labels
+   * @return A filter string that is a concatenation of strings of the form "(labels.key eq value) "
+   *     using the keys and values from {@param labels}.
+   */
+  public static String buildLabelsFilterString(final Map<String, String> labels) {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> l : labels.entrySet()) {
+      sb.append("(labels.").append(l.getKey()).append(" eq ").append(l.getValue()).append(") ");
+    }
+    return sb.toString().trim();
+  }
+}

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
@@ -16,7 +16,6 @@
 
 package com.google.graphite.platforms.plugin.client.util;
 
-import com.google.api.client.json.GenericJson;
 import com.google.common.collect.ImmutableList;
 import java.util.Comparator;
 import java.util.List;
@@ -36,11 +35,11 @@ public class ClientUtil {
    *     then that object will be kept in the final result.
    * @param comparator Defines a comparison between any two objects in {@param items} used for
    *     sorting the result.
-   * @param <T> Any GCP resource type from the GCP client library, extending {@link GenericJson}.
+   * @param <T> The type of the list elements
    * @return An {@link ImmutableList} which is empty if {@param items} is null or empty, and
    *     otherwise is {@param items} filtered and sorted as described above.
    */
-  public static <T extends GenericJson> ImmutableList<T> processResourceList(
+  public static <T> ImmutableList<T> processResourceList(
       final List<T> items, final Predicate<T> filter, final Comparator<T> comparator) {
     if (items == null) {
       return ImmutableList.of();
@@ -55,11 +54,11 @@ public class ClientUtil {
    * @param items A list of GCP resources produced by a GCP client library request.
    * @param comparator Defines a comparison between any two objects in {@param items} used for
    *     sorting the result.
-   * @param <T> Any GCP resource type from the GCP client library, extending {@link GenericJson}.
+   * @param <T> The type of the list elements.
    * @return An {@link ImmutableList} which is empty if {@param items} is null or empty, and
    *     otherwise is {@param items} filtered and sorted as described above.
    */
-  public static <T extends GenericJson> ImmutableList<T> processResourceList(
+  public static <T> ImmutableList<T> processResourceList(
       final List<T> items, final Comparator<T> comparator) {
     return processResourceList(items, n -> true, comparator);
   }

--- a/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
+++ b/gcp-client/src/main/java/com/google/graphite/platforms/plugin/client/util/ClientUtil.java
@@ -16,6 +16,8 @@
 
 package com.google.graphite.platforms.plugin.client.util;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.Comparator;
 import java.util.List;
@@ -25,7 +27,6 @@ import java.util.stream.Collectors;
 
 /** A library of utility functions for common interactions with the GCP client libraries. */
 public class ClientUtil {
-
   /**
    * Given a list of GCP resources, filters the list using the provided filter and sorts according
    * to the provided comparator.
@@ -35,7 +36,7 @@ public class ClientUtil {
    *     then that object will be kept in the final result.
    * @param comparator Defines a comparison between any two objects in {@param items} used for
    *     sorting the result.
-   * @param <T> The type of the list elements
+   * @param <T> The type of the list elements.
    * @return An {@link ImmutableList} which is empty if {@param items} is null or empty, and
    *     otherwise is {@param items} filtered and sorted as described above.
    */
@@ -67,17 +68,18 @@ public class ClientUtil {
    * Removes the prefix information from the provided self link returning only the name.
    *
    * @param selfLink A GCP resource self link, e.g. for an instance:
-   *     "projects/exampleproject/zones/us-west1-a/instances/example"
+   *     "projects/exampleproject/zones/us-west1-a/instances/example".
    * @return The name of the resource referenced by the self-link, i.e. "example".
    */
   public static String nameFromSelfLink(final String selfLink) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(selfLink));
     return selfLink.substring(selfLink.lastIndexOf("/") + 1);
   }
 
   /**
    * Converts a map of GCP labels into the format required to filter a request with these labels.
    *
-   * @param labels A map of key:value GCP labels
+   * @param labels A map of key:value GCP labels.
    * @return A filter string that is a concatenation of strings of the form "(labels.key eq value) "
    *     using the keys and values from {@param labels}.
    */

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ClientFactoryTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ClientFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Tests {@link ClientFactory}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ClientFactoryTest {
+  @Test
+  public void defaultTransport() throws Exception {
+    HttpRequestInitializer httpRequestInitializer = Mockito.mock(HttpRequestInitializer.class);
+    ClientFactory cf =
+        new ClientFactory(Optional.empty(), httpRequestInitializer, "TEST_APPLICATION_NAME");
+    assertNotNull(cf.containerClient());
+    assertNotNull(cf.cloudResourceManagerClient());
+    assertNotNull(cf.computeClient());
+  }
+}

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+/** Tests {@link CloudResourceManagerClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CloudResourceManagerClientTest {
   private static final List<String> TEST_PROJECT_IDS_SORTED =

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
@@ -40,51 +40,51 @@ public class CloudResourceManagerClientTest {
       Arrays.asList("test-project-id-b4", "test-project-id-b2", "test-project-id-b5");
 
   @Test(expected = IOException.class)
-  public void testGetAccountProjectsErrorWithInvalidCredentials() throws IOException {
+  public void testListProjectsErrorWithInvalidCredentials() throws IOException {
     CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
     Mockito.when(wrapper.listProjects()).thenThrow(IOException.class);
     CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
-    client.getAccountProjects();
+    client.listProjects();
   }
 
   @Test
-  public void testGetAccountProjectsNullReturnsEmpty() throws IOException {
+  public void testListProjectsNullReturnsEmpty() throws IOException {
     CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
     Mockito.when(wrapper.listProjects()).thenReturn(null);
     CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
-    List<Project> projects = client.getAccountProjects();
+    List<Project> projects = client.listProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
   }
 
   @Test
-  public void testGetAccountProjectsEmptyReturnsEmpty() throws IOException {
+  public void testListProjectsEmptyReturnsEmpty() throws IOException {
     CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
     Mockito.when(wrapper.listProjects()).thenReturn(ImmutableList.of());
     CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
-    List<Project> projects = client.getAccountProjects();
+    List<Project> projects = client.listProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
   }
 
   @Test
-  public void testGetAccountProjectsSorted() throws IOException {
+  public void testListProjectsSorted() throws IOException {
     CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
     Mockito.when(wrapper.listProjects()).thenReturn(initProjectList(TEST_PROJECT_IDS_SORTED));
     CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
-    List<Project> projects = client.getAccountProjects();
+    List<Project> projects = client.listProjects();
     assertNotNull(projects);
     assertEquals(initProjectList(TEST_PROJECT_IDS_SORTED), projects);
   }
 
   @Test
-  public void testGetAccountProjectsUnsortedReturnedAsSorted() throws IOException {
+  public void testListProjectsUnsortedReturnedAsSorted() throws IOException {
     List<Project> expected = initProjectList(TEST_PROJECT_IDS_UNSORTED);
     expected.sort(Comparator.comparing(Project::getProjectId));
     CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
     Mockito.when(wrapper.listProjects()).thenReturn(initProjectList(TEST_PROJECT_IDS_UNSORTED));
     CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
-    List<Project> projects = client.getAccountProjects();
+    List<Project> projects = client.listProjects();
     assertNotNull(projects);
     assertEquals(expected, projects);
   }

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
@@ -40,13 +40,17 @@ public class CloudResourceManagerClientTest {
 
   @Test(expected = IOException.class)
   public void testGetAccountProjectsErrorWithInvalidCredentials() throws IOException {
-    CloudResourceManagerClient client = setUpClient(null, new IOException());
+    CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
+    Mockito.when(wrapper.listProjects()).thenThrow(IOException.class);
+    CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
     client.getAccountProjects();
   }
 
   @Test
   public void testGetAccountProjectsNullReturnsEmpty() throws IOException {
-    CloudResourceManagerClient client = setUpClient(null, null);
+    CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
+    Mockito.when(wrapper.listProjects()).thenReturn(null);
+    CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
@@ -54,7 +58,9 @@ public class CloudResourceManagerClientTest {
 
   @Test
   public void testGetAccountProjectsEmptyReturnsEmpty() throws IOException {
-    CloudResourceManagerClient client = setUpClient(ImmutableList.of(), null);
+    CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
+    Mockito.when(wrapper.listProjects()).thenReturn(ImmutableList.of());
+    CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
@@ -62,7 +68,9 @@ public class CloudResourceManagerClientTest {
 
   @Test
   public void testGetAccountProjectsSorted() throws IOException {
-    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_SORTED, null);
+    CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
+    Mockito.when(wrapper.listProjects()).thenReturn(initProjectList(TEST_PROJECT_IDS_SORTED));
+    CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(initProjectList(TEST_PROJECT_IDS_SORTED), projects);
@@ -72,22 +80,12 @@ public class CloudResourceManagerClientTest {
   public void testGetAccountProjectsUnsortedReturnedAsSorted() throws IOException {
     List<Project> expected = initProjectList(TEST_PROJECT_IDS_UNSORTED);
     expected.sort(Comparator.comparing(Project::getProjectId));
-    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_UNSORTED, null);
+    CloudResourceManagerWrapper wrapper = Mockito.mock(CloudResourceManagerWrapper.class);
+    Mockito.when(wrapper.listProjects()).thenReturn(initProjectList(TEST_PROJECT_IDS_UNSORTED));
+    CloudResourceManagerClient client = new CloudResourceManagerClient(wrapper);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(expected, projects);
-  }
-
-  private static CloudResourceManagerClient setUpClient(
-      List<String> initial, IOException ioException) throws IOException {
-    CloudResourceManagerWrapper cloudResourceManager =
-        Mockito.mock(CloudResourceManagerWrapper.class);
-    if (ioException != null) {
-      Mockito.when(cloudResourceManager.listProjects()).thenThrow(ioException);
-    } else {
-      Mockito.when(cloudResourceManager.listProjects()).thenReturn(initProjectList(initial));
-    }
-    return new CloudResourceManagerClient(cloudResourceManager);
   }
 
   private static List<Project> initProjectList(List<String> projectIds) {

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
@@ -19,9 +19,6 @@ package com.google.graphite.platforms.plugin.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.api.services.cloudresourcemanager.CloudResourceManager;
-import com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects;
-import com.google.api.services.cloudresourcemanager.model.ListProjectsResponse;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -83,27 +80,20 @@ public class CloudResourceManagerClientTest {
 
   private static CloudResourceManagerClient setUpClient(
       List<String> initial, IOException ioException) throws IOException {
-    CloudResourceManager cloudResourceManager = Mockito.mock(CloudResourceManager.class);
-    Projects projects = Mockito.mock(Projects.class);
-    Mockito.when(cloudResourceManager.projects()).thenReturn(projects);
-    Projects.List projectsListCall = Mockito.mock(Projects.List.class);
-    Mockito.when(projects.list()).thenReturn(projectsListCall);
-
+    CloudResourceManagerWrapper cloudResourceManager =
+        Mockito.mock(CloudResourceManagerWrapper.class);
     if (ioException != null) {
-      Mockito.when(projectsListCall.execute()).thenThrow(ioException);
-    } else if (initial == null) {
-      Mockito.when(projectsListCall.execute())
-          .thenReturn(new ListProjectsResponse().setProjects(null));
+      Mockito.when(cloudResourceManager.listProjects()).thenThrow(ioException);
     } else {
-      List<Project> projectList = initProjectList(initial);
-      Mockito.when(projectsListCall.execute())
-          .thenReturn(new ListProjectsResponse().setProjects(projectList));
+      Mockito.when(cloudResourceManager.listProjects()).thenReturn(initProjectList(initial));
     }
-
     return new CloudResourceManagerClient(cloudResourceManager);
   }
 
   private static List<Project> initProjectList(List<String> projectIds) {
+    if (projectIds == null) {
+      return null;
+    }
     List<Project> projects = new ArrayList<>();
     projectIds.forEach(id -> projects.add(new Project().setProjectId(id)));
     return projects;

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/CloudResourceManagerClientTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects;
+import com.google.api.services.cloudresourcemanager.model.ListProjectsResponse;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudResourceManagerClientTest {
+  private static final List<String> TEST_PROJECT_IDS_SORTED =
+      Arrays.asList("test-project-id-a1", "test-project-id-a2", "test-project-id-a3");
+  private static final List<String> TEST_PROJECT_IDS_UNSORTED =
+      Arrays.asList("test-project-id-b4", "test-project-id-b2", "test-project-id-b5");
+
+  @Test(expected = IOException.class)
+  public void testGetAccountProjectsErrorWithInvalidCredentials() throws IOException {
+    CloudResourceManagerClient client = setUpClient(null, new IOException());
+    client.getAccountProjects();
+  }
+
+  @Test
+  public void testGetAccountProjectsNullReturnsEmpty() throws IOException {
+    CloudResourceManagerClient client = setUpClient(null, null);
+    List<Project> projects = client.getAccountProjects();
+    assertNotNull(projects);
+    assertEquals(ImmutableList.of(), projects);
+  }
+
+  @Test
+  public void testGetAccountProjectsEmptyReturnsEmpty() throws IOException {
+    CloudResourceManagerClient client = setUpClient(ImmutableList.of(), null);
+    List<Project> projects = client.getAccountProjects();
+    assertNotNull(projects);
+    assertEquals(ImmutableList.of(), projects);
+  }
+
+  @Test
+  public void testGetAccountProjectsSorted() throws IOException {
+    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_SORTED, null);
+    List<Project> projects = client.getAccountProjects();
+    assertNotNull(projects);
+    assertEquals(initProjectList(TEST_PROJECT_IDS_SORTED), projects);
+  }
+
+  @Test
+  public void testGetAccountProjectsUnsortedReturnedAsSorted() throws IOException {
+    List<Project> expected = initProjectList(TEST_PROJECT_IDS_UNSORTED);
+    expected.sort(Comparator.comparing(Project::getProjectId));
+    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_UNSORTED, null);
+    List<Project> projects = client.getAccountProjects();
+    assertNotNull(projects);
+    assertEquals(expected, projects);
+  }
+
+  private static CloudResourceManagerClient setUpClient(
+      List<String> initial, IOException ioException) throws IOException {
+    CloudResourceManager cloudResourceManager = Mockito.mock(CloudResourceManager.class);
+    Projects projects = Mockito.mock(Projects.class);
+    Mockito.when(cloudResourceManager.projects()).thenReturn(projects);
+    Projects.List projectsListCall = Mockito.mock(Projects.List.class);
+    Mockito.when(projects.list()).thenReturn(projectsListCall);
+
+    if (ioException != null) {
+      Mockito.when(projectsListCall.execute()).thenThrow(ioException);
+    } else if (initial == null) {
+      Mockito.when(projectsListCall.execute())
+          .thenReturn(new ListProjectsResponse().setProjects(null));
+    } else {
+      List<Project> projectList = initProjectList(initial);
+      Mockito.when(projectsListCall.execute())
+          .thenReturn(new ListProjectsResponse().setProjects(projectList));
+    }
+
+    return new CloudResourceManagerClient(cloudResourceManager);
+  }
+
+  private static List<Project> initProjectList(List<String> projectIds) {
+    List<Project> projects = new ArrayList<>();
+    projectIds.forEach(id -> projects.add(new Project().setProjectId(id)));
+    return projects;
+  }
+}

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -91,8 +91,8 @@ public class ComputeClientTest {
             .setName("us-east1")
             .setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
 
-    assertEquals(3, computeClient.getRegions(TEST_PROJECT_ID).size());
-    assertEquals("eu-central1", computeClient.getRegions(TEST_PROJECT_ID).get(0).getName());
+    assertEquals(3, computeClient.listRegions(TEST_PROJECT_ID).size());
+    assertEquals("eu-central1", computeClient.listRegions(TEST_PROJECT_ID).get(0).getName());
   }
 
   @Test
@@ -102,12 +102,12 @@ public class ComputeClientTest {
     listOfZones.add(new Zone().setRegion("eu-central1").setName("eu-central1-a"));
     listOfZones.add(new Zone().setRegion("us-west1").setName("us-west1-a"));
 
-    assertEquals(2, computeClient.getZones(TEST_PROJECT_ID, "us-west1").size());
+    assertEquals(2, computeClient.listZones(TEST_PROJECT_ID, "us-west1").size());
     assertEquals(
-        "us-west1-a", computeClient.getZones(TEST_PROJECT_ID, "us-west1").get(0).getName());
+        "us-west1-a", computeClient.listZones(TEST_PROJECT_ID, "us-west1").get(0).getName());
 
     listOfZones.clear();
-    assertEquals(0, computeClient.getZones(TEST_PROJECT_ID, "us-west1").size());
+    assertEquals(0, computeClient.listZones(TEST_PROJECT_ID, "us-west1").size());
   }
 
   @Test
@@ -121,8 +121,8 @@ public class ComputeClientTest {
             .setName("d")
             .setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
 
-    assertEquals(3, computeClient.getMachineTypes(TEST_PROJECT_ID, "test").size());
-    assertEquals("a", computeClient.getMachineTypes(TEST_PROJECT_ID, "test").get(0).getName());
+    assertEquals(3, computeClient.listMachineTypes(TEST_PROJECT_ID, "test").size());
+    assertEquals("a", computeClient.listMachineTypes(TEST_PROJECT_ID, "test").get(0).getName());
   }
 
   @Test
@@ -135,8 +135,8 @@ public class ComputeClientTest {
     listOfDiskTypes.add(
         new DiskType().setName("d").setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
 
-    assertEquals(3, computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").size());
-    assertEquals("a", computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").get(0).getName());
+    assertEquals(3, computeClient.listBootDiskTypes(TEST_PROJECT_ID, "test").size());
+    assertEquals("a", computeClient.listBootDiskTypes(TEST_PROJECT_ID, "test").get(0).getName());
   }
 
   @Test
@@ -155,14 +155,14 @@ public class ComputeClientTest {
 
   @Test
   public void getTemplates() throws IOException {
-    assertEquals(0, computeClient.getTemplates(TEST_PROJECT_ID).size());
+    assertEquals(0, computeClient.listTemplates(TEST_PROJECT_ID).size());
 
     listOfInstanceTemplate.add(new InstanceTemplate().setName("z"));
     listOfInstanceTemplate.add(new InstanceTemplate().setName("a"));
     listOfInstanceTemplate.add(new InstanceTemplate().setName("c"));
 
-    assertEquals(3, computeClient.getTemplates(TEST_PROJECT_ID).size());
-    assertEquals("a", computeClient.getTemplates(TEST_PROJECT_ID).get(0).getName());
+    assertEquals(3, computeClient.listTemplates(TEST_PROJECT_ID).size());
+    assertEquals("a", computeClient.listTemplates(TEST_PROJECT_ID).get(0).getName());
   }
 
   @Test

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -17,20 +17,15 @@
 package com.google.graphite.platforms.plugin.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 
-import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.DeprecationStatus;
 import com.google.api.services.compute.model.DiskType;
-import com.google.api.services.compute.model.DiskTypeList;
 import com.google.api.services.compute.model.InstanceTemplate;
-import com.google.api.services.compute.model.InstanceTemplateList;
 import com.google.api.services.compute.model.MachineType;
-import com.google.api.services.compute.model.MachineTypeList;
 import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.Region;
-import com.google.api.services.compute.model.RegionList;
 import com.google.api.services.compute.model.Zone;
-import com.google.api.services.compute.model.ZoneList;
 import com.google.graphite.platforms.plugin.client.util.ClientUtil;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,23 +46,7 @@ public class ComputeClientTest {
   private static final String TEST_PROJECT_ID = "test-project";
   private static final String TEST_TEMPLATE_NAME = "test-template-name";
 
-  @Mock public Compute compute;
-
-  @Mock public Compute.Regions regions;
-
-  @Mock public Compute.Regions.List regionsListCall;
-
-  @Mock public Compute.Zones zones;
-
-  @Mock public Compute.Zones.List zonesListCall;
-
-  @Mock public Compute.MachineTypes machineTypes;
-
-  @Mock Compute.MachineTypes.List machineTypesListCall;
-
-  @Mock public Compute.DiskTypes diskTypes;
-
-  @Mock Compute.DiskTypes.List diskTypesListCall;
+  @Mock public ComputeWrapper compute;
 
   @InjectMocks ComputeClient computeClient;
 
@@ -86,48 +65,21 @@ public class ComputeClientTest {
     listOfInstanceTemplate = new ArrayList<>();
 
     // Mock regions
-    RegionList regionList = new RegionList().setItems(listOfRegions);
-    Mockito.when(regionsListCall.execute()).thenReturn(regionList);
-    Mockito.when(regions.list(TEST_PROJECT_ID)).thenReturn(regionsListCall);
-    Mockito.when(compute.regions()).thenReturn(regions);
+    Mockito.when(compute.listRegions(anyString())).thenReturn(listOfRegions);
 
     // Mock zones
-    ZoneList zoneList = new ZoneList().setItems(listOfZones);
-    Mockito.when(zonesListCall.execute()).thenReturn(zoneList);
-    Mockito.when(zones.list(TEST_PROJECT_ID)).thenReturn(zonesListCall);
-    Mockito.when(compute.zones()).thenReturn(zones);
+    Mockito.when(compute.listZones(anyString())).thenReturn(listOfZones);
 
     // Mock machine types
-    MachineTypeList machineTypeList = new MachineTypeList().setItems(listOfMachineTypes);
-    Mockito.when(machineTypesListCall.execute()).thenReturn(machineTypeList);
-    Mockito.when(machineTypes.list(Mockito.anyString(), Mockito.anyString()))
-        .thenReturn(machineTypesListCall);
-    Mockito.when(compute.machineTypes()).thenReturn(machineTypes);
+    Mockito.when(compute.listMachineTypes(anyString(), anyString())).thenReturn(listOfMachineTypes);
 
     // Mock disk types
-    DiskTypeList diskTypeList = new DiskTypeList().setItems(listOfDiskTypes);
-    Mockito.when(diskTypesListCall.execute()).thenReturn(diskTypeList);
-    Mockito.when(diskTypes.list(Mockito.anyString(), Mockito.anyString()))
-        .thenReturn(diskTypesListCall);
-    Mockito.when(compute.diskTypes()).thenReturn(diskTypes);
+    Mockito.when(compute.listDiskTypes(anyString(), anyString())).thenReturn(listOfDiskTypes);
 
     // Mock instance templates
-    Compute.InstanceTemplates instanceTemplates = Mockito.mock(Compute.InstanceTemplates.class);
-    Compute.InstanceTemplates.List instanceTemplatesList =
-        Mockito.mock(Compute.InstanceTemplates.List.class);
-    Compute.InstanceTemplates.Get instanceTemplatesGet =
-        Mockito.mock(Compute.InstanceTemplates.Get.class);
-    InstanceTemplateList listOfInstanceTemplates =
-        new InstanceTemplateList().setItems(listOfInstanceTemplate);
-
-    Mockito.when(instanceTemplatesGet.execute())
+    Mockito.when(compute.listInstanceTemplates(anyString())).thenReturn(listOfInstanceTemplate);
+    Mockito.when(compute.getInstanceTemplate(anyString(), anyString()))
         .thenReturn(new InstanceTemplate().setName(TEST_TEMPLATE_NAME));
-    Mockito.when(instanceTemplates.get(TEST_PROJECT_ID, TEST_TEMPLATE_NAME))
-        .thenReturn(instanceTemplatesGet);
-
-    Mockito.when(instanceTemplatesList.execute()).thenReturn(listOfInstanceTemplates);
-    Mockito.when(instanceTemplates.list(TEST_PROJECT_ID)).thenReturn(instanceTemplatesList);
-    Mockito.when(compute.instanceTemplates()).thenReturn(instanceTemplates);
   }
 
   @Test

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -31,6 +31,7 @@ import com.google.api.services.compute.model.Region;
 import com.google.api.services.compute.model.RegionList;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
+import com.google.graphite.platforms.plugin.client.util.ClientUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -193,10 +194,10 @@ public class ComputeClientTest {
     String zone;
 
     zone = "https://www.googleapis.com/compute/v1/projects/evandbrown17/zones/asia-east1-a";
-    assertEquals("asia-east1-a", ComputeClient.nameFromSelfLink(zone));
+    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
 
     zone = "asia-east1-a";
-    assertEquals("asia-east1-a", ComputeClient.nameFromSelfLink(zone));
+    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
   }
 
   @Test
@@ -206,7 +207,7 @@ public class ComputeClientTest {
     labels.put("key2", "value2");
     String expect = "(labels.key1 eq value1) (labels.key2 eq value2)";
 
-    String got = ComputeClient.buildLabelsFilterString(labels);
+    String got = ClientUtil.buildLabelsFilterString(labels);
     assertEquals(expect, got);
   }
 

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+/** Tests {@link ComputeClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ComputeClientTest {
 

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -26,12 +26,9 @@ import com.google.api.services.compute.model.MachineType;
 import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.Region;
 import com.google.api.services.compute.model.Zone;
-import com.google.graphite.platforms.plugin.client.util.ClientUtil;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -139,28 +136,6 @@ public class ComputeClientTest {
 
     assertEquals(3, computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").size());
     assertEquals("a", computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").get(0).getName());
-  }
-
-  @Test
-  public void nameFromSelfLink() {
-    String zone;
-
-    zone = "https://www.googleapis.com/compute/v1/projects/evandbrown17/zones/asia-east1-a";
-    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
-
-    zone = "asia-east1-a";
-    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
-  }
-
-  @Test
-  public void labelsToFilterString() {
-    Map<String, String> labels = new LinkedHashMap<>();
-    labels.put("key1", "value1");
-    labels.put("key2", "value2");
-    String expect = "(labels.key1 eq value1) (labels.key2 eq value2)";
-
-    String got = ClientUtil.buildLabelsFilterString(labels);
-    assertEquals(expect, got);
   }
 
   @Test

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -40,7 +40,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 /** Tests {@link ComputeClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ComputeClientTest {
-
   private static final String TEST_PROJECT_ID = "test-project";
   private static final String TEST_TEMPLATE_NAME = "test-template-name";
 

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -171,8 +171,8 @@ public class ComputeClientTest {
             .setName("d")
             .setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
 
-    assertEquals(3, computeClient.getMachineTypes("", "test").size());
-    assertEquals("a", computeClient.getMachineTypes("", "test").get(0).getName());
+    assertEquals(3, computeClient.getMachineTypes(TEST_PROJECT_ID, "test").size());
+    assertEquals("a", computeClient.getMachineTypes(TEST_PROJECT_ID, "test").get(0).getName());
   }
 
   @Test
@@ -185,8 +185,8 @@ public class ComputeClientTest {
     listOfDiskTypes.add(
         new DiskType().setName("d").setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
 
-    assertEquals(3, computeClient.getBootDiskTypes("", "test").size());
-    assertEquals("a", computeClient.getBootDiskTypes("", "test").get(0).getName());
+    assertEquals(3, computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").size());
+    assertEquals("a", computeClient.getBootDiskTypes(TEST_PROJECT_ID, "test").get(0).getName());
   }
 
   @Test

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -43,10 +43,8 @@ public class ComputeClientTest {
   private static final String TEST_PROJECT_ID = "test-project";
   private static final String TEST_TEMPLATE_NAME = "test-template-name";
 
-  @Mock public ComputeWrapper compute;
-
-  @InjectMocks ComputeClient computeClient;
-
+  @Mock private ComputeWrapper compute;
+  @InjectMocks private ComputeClient computeClient;
   private List<Region> listOfRegions;
   private List<Zone> listOfZones;
   private List<MachineType> listOfMachineTypes;

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ComputeClientTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.DeprecationStatus;
+import com.google.api.services.compute.model.DiskType;
+import com.google.api.services.compute.model.DiskTypeList;
+import com.google.api.services.compute.model.InstanceTemplate;
+import com.google.api.services.compute.model.InstanceTemplateList;
+import com.google.api.services.compute.model.MachineType;
+import com.google.api.services.compute.model.MachineTypeList;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.Region;
+import com.google.api.services.compute.model.RegionList;
+import com.google.api.services.compute.model.Zone;
+import com.google.api.services.compute.model.ZoneList;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ComputeClientTest {
+
+  private static final String TEST_PROJECT_ID = "test-project";
+  private static final String TEST_TEMPLATE_NAME = "test-template-name";
+
+  @Mock public Compute compute;
+
+  @Mock public Compute.Regions regions;
+
+  @Mock public Compute.Regions.List regionsListCall;
+
+  @Mock public Compute.Zones zones;
+
+  @Mock public Compute.Zones.List zonesListCall;
+
+  @Mock public Compute.MachineTypes machineTypes;
+
+  @Mock Compute.MachineTypes.List machineTypesListCall;
+
+  @Mock public Compute.DiskTypes diskTypes;
+
+  @Mock Compute.DiskTypes.List diskTypesListCall;
+
+  @InjectMocks ComputeClient computeClient;
+
+  private List<Region> listOfRegions;
+  private List<Zone> listOfZones;
+  private List<MachineType> listOfMachineTypes;
+  private List<DiskType> listOfDiskTypes;
+  private List<InstanceTemplate> listOfInstanceTemplate;
+
+  @Before
+  public void init() throws Exception {
+    listOfRegions = new ArrayList<>();
+    listOfZones = new ArrayList<>();
+    listOfMachineTypes = new ArrayList<>();
+    listOfDiskTypes = new ArrayList<>();
+    listOfInstanceTemplate = new ArrayList<>();
+
+    // Mock regions
+    RegionList regionList = new RegionList().setItems(listOfRegions);
+    Mockito.when(regionsListCall.execute()).thenReturn(regionList);
+    Mockito.when(regions.list(TEST_PROJECT_ID)).thenReturn(regionsListCall);
+    Mockito.when(compute.regions()).thenReturn(regions);
+
+    // Mock zones
+    ZoneList zoneList = new ZoneList().setItems(listOfZones);
+    Mockito.when(zonesListCall.execute()).thenReturn(zoneList);
+    Mockito.when(zones.list(TEST_PROJECT_ID)).thenReturn(zonesListCall);
+    Mockito.when(compute.zones()).thenReturn(zones);
+
+    // Mock machine types
+    MachineTypeList machineTypeList = new MachineTypeList().setItems(listOfMachineTypes);
+    Mockito.when(machineTypesListCall.execute()).thenReturn(machineTypeList);
+    Mockito.when(machineTypes.list(Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(machineTypesListCall);
+    Mockito.when(compute.machineTypes()).thenReturn(machineTypes);
+
+    // Mock disk types
+    DiskTypeList diskTypeList = new DiskTypeList().setItems(listOfDiskTypes);
+    Mockito.when(diskTypesListCall.execute()).thenReturn(diskTypeList);
+    Mockito.when(diskTypes.list(Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(diskTypesListCall);
+    Mockito.when(compute.diskTypes()).thenReturn(diskTypes);
+
+    // Mock instance templates
+    Compute.InstanceTemplates instanceTemplates = Mockito.mock(Compute.InstanceTemplates.class);
+    Compute.InstanceTemplates.List instanceTemplatesList =
+        Mockito.mock(Compute.InstanceTemplates.List.class);
+    Compute.InstanceTemplates.Get instanceTemplatesGet =
+        Mockito.mock(Compute.InstanceTemplates.Get.class);
+    InstanceTemplateList listOfInstanceTemplates =
+        new InstanceTemplateList().setItems(listOfInstanceTemplate);
+
+    Mockito.when(instanceTemplatesGet.execute())
+        .thenReturn(new InstanceTemplate().setName(TEST_TEMPLATE_NAME));
+    Mockito.when(instanceTemplates.get(TEST_PROJECT_ID, TEST_TEMPLATE_NAME))
+        .thenReturn(instanceTemplatesGet);
+
+    Mockito.when(instanceTemplatesList.execute()).thenReturn(listOfInstanceTemplates);
+    Mockito.when(instanceTemplates.list(TEST_PROJECT_ID)).thenReturn(instanceTemplatesList);
+    Mockito.when(compute.instanceTemplates()).thenReturn(instanceTemplates);
+  }
+
+  @Test
+  public void getRegions() throws IOException {
+    listOfRegions.clear();
+    listOfRegions.add(new Region().setName("us-west1"));
+    listOfRegions.add(new Region().setName("eu-central1"));
+    listOfRegions.add(new Region().setName("us-central1"));
+    listOfRegions.add(
+        new Region()
+            .setName("us-east1")
+            .setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
+
+    assertEquals(3, computeClient.getRegions(TEST_PROJECT_ID).size());
+    assertEquals("eu-central1", computeClient.getRegions(TEST_PROJECT_ID).get(0).getName());
+  }
+
+  @Test
+  public void getZones() throws IOException {
+    listOfZones.clear();
+    listOfZones.add(new Zone().setRegion("us-west1").setName("us-west1-b"));
+    listOfZones.add(new Zone().setRegion("eu-central1").setName("eu-central1-a"));
+    listOfZones.add(new Zone().setRegion("us-west1").setName("us-west1-a"));
+
+    assertEquals(2, computeClient.getZones(TEST_PROJECT_ID, "us-west1").size());
+    assertEquals(
+        "us-west1-a", computeClient.getZones(TEST_PROJECT_ID, "us-west1").get(0).getName());
+
+    listOfZones.clear();
+    assertEquals(0, computeClient.getZones(TEST_PROJECT_ID, "us-west1").size());
+  }
+
+  @Test
+  public void getMachineTypes() throws IOException {
+    listOfMachineTypes.clear();
+    listOfMachineTypes.add(new MachineType().setName("b"));
+    listOfMachineTypes.add(new MachineType().setName("a"));
+    listOfMachineTypes.add(new MachineType().setName("z"));
+    listOfMachineTypes.add(
+        new MachineType()
+            .setName("d")
+            .setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
+
+    assertEquals(3, computeClient.getMachineTypes("", "test").size());
+    assertEquals("a", computeClient.getMachineTypes("", "test").get(0).getName());
+  }
+
+  @Test
+  public void getDiskTypes() throws IOException {
+    listOfDiskTypes.clear();
+    listOfDiskTypes.add(new DiskType().setName("b"));
+    listOfDiskTypes.add(new DiskType().setName("a"));
+    listOfDiskTypes.add(new DiskType().setName("z"));
+    listOfDiskTypes.add(new DiskType().setName("local-d"));
+    listOfDiskTypes.add(
+        new DiskType().setName("d").setDeprecated(new DeprecationStatus().setState("DEPRECATED")));
+
+    assertEquals(3, computeClient.getBootDiskTypes("", "test").size());
+    assertEquals("a", computeClient.getBootDiskTypes("", "test").get(0).getName());
+  }
+
+  @Test
+  public void nameFromSelfLink() {
+    String zone;
+
+    zone = "https://www.googleapis.com/compute/v1/projects/evandbrown17/zones/asia-east1-a";
+    assertEquals("asia-east1-a", ComputeClient.nameFromSelfLink(zone));
+
+    zone = "asia-east1-a";
+    assertEquals("asia-east1-a", ComputeClient.nameFromSelfLink(zone));
+  }
+
+  @Test
+  public void labelsToFilterString() {
+    Map<String, String> labels = new LinkedHashMap<>();
+    labels.put("key1", "value1");
+    labels.put("key2", "value2");
+    String expect = "(labels.key1 eq value1) (labels.key2 eq value2)";
+
+    String got = ComputeClient.buildLabelsFilterString(labels);
+    assertEquals(expect, got);
+  }
+
+  @Test
+  public void mergeMetadataItemsTest() {
+    List<Metadata.Items> newItems = new ArrayList<>();
+    newItems.add(new Metadata.Items().setKey("ssh-keys").setValue("new"));
+
+    List<Metadata.Items> existingItems = new ArrayList<>();
+    existingItems.add(new Metadata.Items().setKey("ssh-keys").setValue("old"));
+    existingItems.add(new Metadata.Items().setKey("no-overwrite").setValue("no-overwrite"));
+
+    List<Metadata.Items> merged = ComputeClient.mergeMetadataItems(newItems, existingItems);
+
+    assertEquals(existingItems.size(), merged.size());
+  }
+
+  @Test
+  public void getTemplates() throws IOException {
+    assertEquals(0, computeClient.getTemplates(TEST_PROJECT_ID).size());
+
+    listOfInstanceTemplate.add(new InstanceTemplate().setName("z"));
+    listOfInstanceTemplate.add(new InstanceTemplate().setName("a"));
+    listOfInstanceTemplate.add(new InstanceTemplate().setName("c"));
+
+    assertEquals(3, computeClient.getTemplates(TEST_PROJECT_ID).size());
+    assertEquals("a", computeClient.getTemplates(TEST_PROJECT_ID).get(0).getName());
+  }
+
+  @Test
+  public void getTemplate() throws IOException {
+    assertEquals(
+        new InstanceTemplate().setName(TEST_TEMPLATE_NAME),
+        computeClient.getTemplate(TEST_PROJECT_ID, TEST_TEMPLATE_NAME));
+  }
+}

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ContainerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ContainerClientTest.java
@@ -38,44 +38,52 @@ public class ContainerClientTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithNullProjectId() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(null, TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithNullLocation() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(TEST_PROJECT_ID, null, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithNullClusterName() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithEmptyProjectId() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster("", TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithEmptyLocation() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(TEST_PROJECT_ID, "", TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithEmptyClusterName() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, "");
   }
 
   @Test
   public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
-    ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
     Cluster expected = new Cluster().setName(TEST_CLUSTER);
+    Mockito.when(container.getCluster(anyString(), anyString(), anyString())).thenReturn(expected);
+    ContainerClient containerClient = new ContainerClient(container);
     Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
     assertNotNull(response);
     assertEquals(expected, response);
@@ -83,25 +91,33 @@ public class ContainerClientTest {
 
   @Test(expected = IOException.class)
   public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
-    ContainerClient containerClient = setUpGetClient(null, new IOException());
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.getCluster(anyString(), anyString(), anyString()))
+        .thenThrow(IOException.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListAllClustersErrorWithNullProjectId() throws IOException {
-    ContainerClient containerClient = setUpListClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.listAllClusters(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListAllClustersErrorWithEmptyProjectId() throws IOException {
-    ContainerClient containerClient = setUpListClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.listAllClusters("");
   }
 
   @Test
   public void testListAllClustersWithValidInputsWhenClustersExist() throws IOException {
-    ContainerClient containerClient = setUpListClient(ImmutableList.of(TEST_CLUSTER), null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.listClusters(anyString(), anyString()))
+        .thenReturn(initClusterList(ImmutableList.of(TEST_CLUSTER)));
+    ContainerClient containerClient = new ContainerClient(container);
     List<Cluster> expected = initClusterList(ImmutableList.of(TEST_CLUSTER));
     List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
     assertNotNull(response);
@@ -110,8 +126,10 @@ public class ContainerClientTest {
 
   @Test
   public void testListAllClustersSortedWithMultipleClusters() throws IOException {
-    ContainerClient containerClient =
-        setUpListClient(ImmutableList.of(TEST_CLUSTER, OTHER_CLUSTER), null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.listClusters(anyString(), anyString()))
+        .thenReturn(initClusterList(ImmutableList.of(TEST_CLUSTER, OTHER_CLUSTER)));
+    ContainerClient containerClient = new ContainerClient(container);
     List<Cluster> expected = initClusterList(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER));
     List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
     assertNotNull(response);
@@ -120,7 +138,9 @@ public class ContainerClientTest {
 
   @Test
   public void testListAllClustersWithValidInputsWhenClustersIsNull() throws IOException {
-    ContainerClient containerClient = setUpListClient(null, null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.listClusters(anyString(), anyString())).thenReturn(null);
+    ContainerClient containerClient = new ContainerClient(container);
     List<Cluster> expected = ImmutableList.of();
     List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
     assertNotNull(response);
@@ -129,7 +149,9 @@ public class ContainerClientTest {
 
   @Test
   public void testListAllClustersEmptyWithValidProjectWithNoClusters() throws IOException {
-    ContainerClient containerClient = setUpListClient(ImmutableList.of(), null);
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.listClusters(anyString(), anyString())).thenReturn(ImmutableList.of());
+    ContainerClient containerClient = new ContainerClient(container);
     List<Cluster> expected = ImmutableList.of();
     List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
     assertNotNull(response);
@@ -138,7 +160,9 @@ public class ContainerClientTest {
 
   @Test(expected = IOException.class)
   public void testListAllClustersThrowsErrorWithInvalidProject() throws IOException {
-    ContainerClient containerClient = setUpListClient(null, new IOException());
+    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
+    Mockito.when(container.listClusters(anyString(), anyString())).thenThrow(IOException.class);
+    ContainerClient containerClient = new ContainerClient(container);
     containerClient.listAllClusters(TEST_PROJECT_ID);
   }
 
@@ -149,34 +173,5 @@ public class ContainerClientTest {
     List<Cluster> clusters = new ArrayList<>();
     clusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setLocation(TEST_LOCATION)));
     return clusters;
-  }
-
-  private static ContainerClient setUpGetClient(String clusterName, IOException ioException)
-      throws IOException {
-    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
-    ContainerClient client = new ContainerClient(container);
-
-    if (ioException != null) {
-      Mockito.when(container.getCluster(anyString(), anyString(), anyString()))
-          .thenThrow(ioException);
-    } else {
-      Mockito.when(container.getCluster(anyString(), anyString(), anyString()))
-          .thenReturn(new Cluster().setName(clusterName));
-    }
-    return client;
-  }
-
-  private static ContainerClient setUpListClient(List<String> clusters, IOException ioException)
-      throws IOException {
-    ContainerWrapper container = Mockito.mock(ContainerWrapper.class);
-    ContainerClient client = new ContainerClient(container);
-
-    if (ioException != null) {
-      Mockito.when(container.listClusters(anyString(), anyString())).thenThrow(ioException);
-    } else {
-      Mockito.when(container.listClusters(anyString(), anyString()))
-          .thenReturn(initClusterList(clusters));
-    }
-    return client;
   }
 }

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ContainerClientTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/ContainerClientTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.graphite.platforms.plugin.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import com.google.api.services.container.Container;
+import com.google.api.services.container.Container.Projects.Locations.Clusters;
+import com.google.api.services.container.model.Cluster;
+import com.google.api.services.container.model.ListClustersResponse;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Tests {@link ContainerClient}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerClientTest {
+  private static final String TEST_PROJECT_ID = "test-project-id";
+  private static final String TEST_LOCATION = "us-west1-a";
+  private static final String TEST_CLUSTER = "testCluster";
+  private static final String OTHER_CLUSTER = "otherCluster";
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullProjectId() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(null, TEST_LOCATION, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullLocation() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, null, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullClusterName() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyProjectId() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster("", TEST_LOCATION, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyLocation() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, "", TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyClusterName() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, "");
+  }
+
+  @Test
+  public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
+    ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);
+    Cluster expected = new Cluster().setName(TEST_CLUSTER);
+    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, new IOException());
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListAllClustersErrorWithNullProjectId() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listAllClusters(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListAllClustersErrorWithEmptyProjectId() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listAllClusters("");
+  }
+
+  @Test
+  public void testListAllClustersWithValidInputsWhenClustersExist() throws IOException {
+    ContainerClient containerClient = setUpListClient(ImmutableList.of(TEST_CLUSTER), null);
+    List<Cluster> expected = initClusterList(ImmutableList.of(TEST_CLUSTER));
+    List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListAllClustersSortedWithMultipleClusters() throws IOException {
+    ContainerClient containerClient =
+        setUpListClient(ImmutableList.of(TEST_CLUSTER, OTHER_CLUSTER), null);
+    List<Cluster> expected = initClusterList(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER));
+    List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListAllClustersWithValidInputsWhenClustersIsNull() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    List<Cluster> expected = ImmutableList.of();
+    List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListAllClustersEmptyWithValidProjectWithNoClusters() throws IOException {
+    ContainerClient containerClient = setUpListClient(ImmutableList.of(), null);
+    List<Cluster> expected = ImmutableList.of();
+    List<Cluster> response = containerClient.listAllClusters(TEST_PROJECT_ID);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test(expected = IOException.class)
+  public void testListAllClustersThrowsErrorWithInvalidProject() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, new IOException());
+    containerClient.listAllClusters(TEST_PROJECT_ID);
+  }
+
+  private static List<Cluster> initClusterList(List<String> clusterNames) {
+    List<Cluster> clusters = new ArrayList<>();
+    clusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setLocation(TEST_LOCATION)));
+    return clusters;
+  }
+
+  private static ContainerClient setUpClient(Clusters.List listCall, Clusters.Get getCall)
+      throws IOException {
+    Container container = Mockito.mock(Container.class);
+    Container.Projects projects = Mockito.mock(Container.Projects.class);
+    Container.Projects.Locations locations = Mockito.mock(Container.Projects.Locations.class);
+    Clusters clusters = Mockito.mock(Container.Projects.Locations.Clusters.class);
+    Mockito.when(container.projects()).thenReturn(projects);
+    Mockito.when(projects.locations()).thenReturn(locations);
+    Mockito.when(locations.clusters()).thenReturn(clusters);
+    if (getCall != null) {
+      Mockito.when(clusters.get(anyString())).thenReturn(getCall);
+    }
+    if (listCall != null) {
+      Mockito.when(clusters.list(anyString())).thenReturn(listCall);
+    }
+    return new ContainerClient(container);
+  }
+
+  private static ContainerClient setUpGetClient(String clusterName, IOException ioException)
+      throws IOException {
+    Clusters.Get getCall = Mockito.mock(Clusters.Get.class);
+    ContainerClient client = setUpClient(null, getCall);
+
+    if (ioException != null) {
+      Mockito.when(getCall.execute()).thenThrow(ioException);
+    } else {
+      Mockito.when(getCall.execute()).thenReturn(new Cluster().setName(clusterName));
+    }
+    return client;
+  }
+
+  private static ContainerClient setUpListClient(List<String> clusters, IOException ioException)
+      throws IOException {
+    Clusters.List listCall = Mockito.mock(Clusters.List.class);
+    ContainerClient client = setUpClient(listCall, null);
+
+    if (ioException != null) {
+      Mockito.when(listCall.execute()).thenThrow(ioException);
+    } else if (clusters == null) {
+      Mockito.when(listCall.execute()).thenReturn(new ListClustersResponse().setClusters(null));
+    } else {
+      Mockito.when(listCall.execute())
+          .thenReturn(new ListClustersResponse().setClusters(initClusterList(clusters)));
+    }
+    return client;
+  }
+}

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.graphite.platforms.plugin.client.util;
+
+import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.services.compute.model.Zone;
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/** Test suite for {@link ClientUtil}. */
+public class ClientUtilTest {
+
+  @Test
+  public void testProcessResourceListNullItems() {
+    List<String> result = processResourceList(null, String::compareTo);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testProcessResourceListEmptyItems() {
+    List<String> result = processResourceList(ImmutableList.of(), String::compareTo);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testProcessResourceListWithComparator() {
+    List<String> expected = ImmutableList.of("example", "foo", "test");
+    List<String> result =
+        processResourceList(ImmutableList.of("test", "example", "foo"), String::compareTo);
+    assertNotNull(result);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testProcessResourceListWithFilter() {
+    Zone zoneA = new Zone().setName("us-west1-a").setRegion("us-west1");
+    Zone zoneB = new Zone().setName("us-central1-b").setRegion("us-central1");
+    Zone zoneC = new Zone().setName("us-east2-c").setRegion("us-east2");
+    List<Zone> expected = ImmutableList.of(zoneB, zoneA);
+    List<Zone> result =
+        processResourceList(
+            ImmutableList.of(zoneA, zoneB, zoneC),
+            zone -> !zone.getRegion().equals("us-east2"),
+            Comparator.comparing(Zone::getName));
+    assertNotNull(result);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testNameFromSelfLink() {
+    String zone = "https://www.googleapis.com/compute/v1/projects/evandbrown17/zones/asia-east1-a";
+    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
+  }
+
+  @Test
+  public void testNameFromSelfLinkOnlyName() {
+    String zone = "asia-east1-a";
+    assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
+  }
+
+  @Test
+  public void testLabelsToFilterString() {
+    Map<String, String> labels = new LinkedHashMap<>();
+    labels.put("key1", "value1");
+    labels.put("key2", "value2");
+    String expect = "(labels.key1 eq value1) (labels.key2 eq value2)";
+
+    String got = ClientUtil.buildLabelsFilterString(labels);
+    assertEquals(expect, got);
+  }
+}

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
-/** Test suite for {@link ClientUtil}. */
+/** Tests {@link ClientUtil}. */
 public class ClientUtilTest {
 
   @Test

--- a/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
+++ b/gcp-client/src/test/java/com/google/graphite/platforms/plugin/client/util/ClientUtilTest.java
@@ -16,6 +16,7 @@
 
 package com.google.graphite.platforms.plugin.client.util;
 
+import static com.google.graphite.platforms.plugin.client.util.ClientUtil.nameFromSelfLink;
 import static com.google.graphite.platforms.plugin.client.util.ClientUtil.processResourceList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,7 +32,6 @@ import org.junit.Test;
 
 /** Tests {@link ClientUtil}. */
 public class ClientUtilTest {
-
   @Test
   public void testProcessResourceListNullItems() {
     List<String> result = processResourceList(null, String::compareTo);
@@ -80,6 +80,16 @@ public class ClientUtilTest {
   public void testNameFromSelfLinkOnlyName() {
     String zone = "asia-east1-a";
     assertEquals("asia-east1-a", ClientUtil.nameFromSelfLink(zone));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNameFromSelfLinkNull() {
+    nameFromSelfLink(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNameFromSelfLinkEmpty() {
+    nameFromSelfLink("");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -61,30 +61,42 @@
     <java.level>8</java.level>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <google.api.version>1.25.0</google.api.version>
+    <mockito.version>2.10.0</mockito.version>
+    <junit.version>4.12</junit.version>
+    <google.guava.version>19.0</google.guava.version>
+    <maven-compiler.version>3.8.0</maven-compiler.version>
+    <xml-format-maven.version>3.0.7</xml-format-maven.version>
+    <tidy-maven.version>1.1.0</tidy-maven.version>
+    <fmt-maven.version>2.6.0</fmt-maven.version>
+    <maven-failsafe.version>2.20.1</maven-failsafe.version>
+    <maven-surefire.version>${maven-failsafe.version}</maven-surefire.version>
+    <findbugs-maven.version>3.0.1</findbugs-maven.version>
+    <cobertura-maven.version>2.7</cobertura-maven.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.10.0</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.25.0</version>
+      <version>${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>${google.guava.version}</version>
     </dependency>
   </dependencies>
 
@@ -93,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>${maven-compiler.version}</version>
         <configuration>
           <compilerArgument>-Xlint:all</compilerArgument>
         </configuration>
@@ -101,7 +113,7 @@
       <plugin>
         <groupId>au.com.acegi</groupId>
         <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.0.7</version>
+        <version>${xml-format-maven.version}</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -118,7 +130,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>tidy-maven-plugin</artifactId>
-        <version>1.1.0</version>
+        <version>${tidy-maven.version}</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -132,7 +144,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.6.0</version>
+        <version>${fmt-maven.version}</version>
         <executions>
           <execution>
             <goals>
@@ -144,7 +156,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>${maven-failsafe.version}</version>
         <executions>
           <execution>
             <goals>
@@ -159,8 +171,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>${maven-surefire.version}</version>
         <configuration>
           <skipTests>${skip.surefire.tests}</skipTests>
         </configuration>
@@ -168,7 +181,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>${findbugs-maven.version}</version>
         <configuration>
           <skip>true</skip>
           <effort>Max</effort>
@@ -186,7 +199,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
+        <version>${cobertura-maven.version}</version>
         <configuration>
           <instrumentation>
             <excludes/>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
   <groupId>com.google.graphite</groupId>
   <artifactId>gcp-plugin-core-java</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
   <name>GCP Plugin Core for Java</name>
   <description>This set of libraries provides common code used for Google Cloud Graphite's integrations to enable using GCP with popular open source platforms.</description>
@@ -52,6 +53,10 @@
     </developer>
   </developers>
 
+  <modules>
+    <module>gcp-client</module>
+  </modules>
+
   <properties>
     <java.level>8</java.level>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -70,26 +75,6 @@
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-container</artifactId>
-      <version>v1-rev57-1.25.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-compute</artifactId>
-      <version>v1-rev199-1.22.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-cloudresourcemanager</artifactId>
-      <version>v1-rev535-1.25.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api-client</groupId>
-      <artifactId>google-api-client</artifactId>
-      <version>1.25.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
This change largely copies the existing clients across the GCE and GKE jenkins plugins, with a few changes to remove anything related to Jenkins and to account for changes in the Google Client Libraries, in particular the fact that classes like "ZoneList" have been made final so they can not be mocked.

I originally wanted to include a module for anything Jenkins specific, including OAuth, but that is a much larger change than I anticipated, especially because of all of the downstream changes it requires. For now, this is a good compromise and will just require the plugins to provide the HttpRequestInitializer which contains the Credential object needed in a ClientFactory wrapper class. I'll have a sample PR for the GCE and GKE plugins which make use of this soon.