### PR TITLE
Use version 20.0 of guava, version 1.25.0 of client libraries, and version 1.21.0 of http-client.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline {
     environment {
         GOOGLE_PROJECT_ID = "${GPCJ_IT_PROJECT_ID}"
         BUILD_ARTIFACTS_BUCKET = "${GPCJ_IT_BUCKET}"
-        BUILD_ARTIFACTS = "gpcj-${BRANCH_NAME}-${BUILD_ID}.tar.gz"
+        CLEAN_BRANCH_NAME = "${BRANCH_NAME}".replaceAll("[/&;<>|\\]]", "_")
+        BUILD_ARTIFACTS = "gpcj-${CLEAN_BRANCH_NAME}-${BUILD_ID}.tar.gz"
     }
 
     stages {

--- a/gcp-client/pom.xml
+++ b/gcp-client/pom.xml
@@ -18,11 +18,11 @@
   <parent>
     <groupId>com.google.cloud.graphite</groupId>
     <artifactId>gcp-plugin-core-java</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gcp-client</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>GCP Plugin Clients</name>
@@ -30,7 +30,7 @@
 
   <properties>
     <container.revision>74</container.revision>
-    <compute.revision>213</compute.revision>
+    <compute.revision>214</compute.revision>
     <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
     <durian.version>3.4.0</durian.version>
     <awaitility.version>3.1.6</awaitility.version>
@@ -57,6 +57,12 @@
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
       <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>com.google.http-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.diffplug.durian</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>com.google.cloud.graphite</groupId>
   <artifactId>gcp-plugin-core-java</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>GCP Plugin Core for Java</name>
@@ -74,10 +74,10 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <google.api.version>1.24.1</google.api.version>
+    <google.api.version>1.25.0</google.api.version>
     <mockito.version>2.10.0</mockito.version>
     <junit.version>4.12</junit.version>
-    <google.guava.version>14.0.1</google.guava.version>
+    <google.guava.version>20.0</google.guava.version>
     <maven-compiler.version>3.8.0</maven-compiler.version>
     <xml-format-maven.version>3.0.7</xml-format-maven.version>
     <tidy-maven.version>1.1.0</tidy-maven.version>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>${google.api.version}</version>
+      <version>1.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <google.api.version>1.25.0</google.api.version>
+    <google.http.version>1.21.0</google.http.version>
     <mockito.version>2.10.0</mockito.version>
     <junit.version>4.12</junit.version>
     <google.guava.version>20.0</google.guava.version>
@@ -110,7 +111,13 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.21.0</version>
+      <version>${google.http.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
See jenkinsci/google-oauth-plugin/pull/75 for explanation on pinning to version 1.21.0 for http-client.